### PR TITLE
avoids name conflicts with default kube env names

### DIFF
--- a/gateway-service/src/main/resources/configs/common/application.conf
+++ b/gateway-service/src/main/resources/configs/common/application.conf
@@ -4,21 +4,21 @@ service.admin.port = 50072
 
 entity.service.config = {
   host = localhost
-  host = ${?ENTITY_SERVICE_HOST}
+  host = ${?ENTITY_SERVICE_HOST_CONFIG}
   port = 50061
-  port = ${?ENTITY_SERVICE_PORT}
+  port = ${?ENTITY_SERVICE_PORT_CONFIG}
 }
 query.service.config = {
   host = localhost
-  host = ${?QUERY_SERVICE_HOST}
+  host = ${?QUERY_SERVICE_HOST_CONFIG}
   port = 8090
-  port = ${?QUERY_SERVICE_PORT}
+  port = ${?QUERY_SERVICE_PORT_CONFIG}
 }
 attributes.service.config = {
   host = localhost
-  host = ${?ATTRIBUTE_SERVICE_HOST}
+  host = ${?ATTRIBUTE_SERVICE_HOST_CONFIG}
   port = 9012
-  port = ${?ATTRIBUTE_SERVICE_PORT}
+  port = ${?ATTRIBUTE_SERVICE_PORT_CONFIG}
 }
 interaction.config = [
   {


### PR DESCRIPTION
- kube adds default env as `ATTRIBUTE_SERVICE_PORT`, so adding suffix `_CONFIG` for app related host/port config.