### PR TITLE
Reverting the optimization to use DISTINCTCOUNT for entity total query.

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcher.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcher.java
@@ -37,9 +37,7 @@ import org.hypertrace.gateway.service.entity.EntitiesRequestContext;
 import org.hypertrace.gateway.service.entity.EntitiesRequestValidator;
 import org.hypertrace.gateway.service.entity.EntityKey;
 import org.hypertrace.gateway.service.v1.common.AggregatedMetricValue;
-import org.hypertrace.gateway.service.v1.common.ColumnIdentifier;
 import org.hypertrace.gateway.service.v1.common.Expression.ValueCase;
-import org.hypertrace.gateway.service.v1.common.FunctionExpression;
 import org.hypertrace.gateway.service.v1.common.FunctionType;
 import org.hypertrace.gateway.service.v1.common.Health;
 import org.hypertrace.gateway.service.v1.common.Interval;
@@ -643,101 +641,7 @@ public class QueryServiceEntityFetcher implements IEntityFetcher {
             requestContext, AttributeScope.valueOf(entitiesRequest.getEntityType()));
     // Validate EntitiesRequest
     entitiesRequestValidator.validate(entitiesRequest, attributeMetadataMap);
-
-    List<String> entityIdAttributes =
-        AttributeMetadataUtil.getIdAttributeIds(
-            attributeMetadataProvider, requestContext, entitiesRequest.getEntityType());
-
-    if (entityIdAttributes.size() == 1) {
-      return getTotalEntitiesForSingleEntityId(entityIdAttributes.get(0), requestContext, entitiesRequest, attributeMetadataMap);
-    } else {
-      return getTotalEntitiesForMultipleEntityId(requestContext, entitiesRequest);
-    }
-  }
-
-  private int getTotalEntitiesForSingleEntityId(String entityIdAttribute,
-                                                EntitiesRequestContext requestContext,
-                                                EntitiesRequest entitiesRequest,
-                                                Map<String, AttributeMetadata> attributeMetadataMap) {
-    Filter.Builder filterBuilder =
-        constructQueryServiceFilter(entitiesRequest, requestContext, List.of(entityIdAttribute));
-
-    String alias = FunctionType.DISTINCTCOUNT + "_entityId_forTotal";
-    org.hypertrace.gateway.service.v1.common.Expression distinctCountExpression = org.hypertrace.gateway.service.v1.common.Expression.newBuilder()
-        .setFunction(
-            FunctionExpression.newBuilder()
-                .setFunction(FunctionType.DISTINCTCOUNT)
-                .addArguments(
-                    org.hypertrace.gateway.service.v1.common.Expression.newBuilder()
-                        .setColumnIdentifier(
-                            ColumnIdentifier.newBuilder()
-                                .setColumnName(entityIdAttribute)
-                                .build()
-                        )
-                        .build()
-                )
-                .setAlias(alias)
-                .build()
-        )
-        .build();
-    requestContext.mapAliasToFunctionExpression(alias, distinctCountExpression.getFunction());
-
-    QueryRequest.Builder builder =
-        QueryRequest.newBuilder()
-            .setFilter(filterBuilder)
-            .addAggregation(QueryAndGatewayDtoConverter.convertToQueryExpression(distinctCountExpression))
-            .setOffset(0)
-            .setLimit(1);
-
-    QueryRequest queryRequest = builder.build();
-
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Sending Query to Query Service ======== \n {}", queryRequest);
-    }
-
-    Iterator<ResultSetChunk> resultSetChunkIterator =
-        queryServiceClient.executeQuery(queryRequest, requestContext.getHeaders(), requestTimeout);
-
-    while (resultSetChunkIterator.hasNext()) {
-      ResultSetChunk chunk = resultSetChunkIterator.next();
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Received chunk: " + chunk.toString());
-      }
-
-      if (chunk.getRowCount() < 1) {
-        LOG.warn("Empty row count for entities total.");
-        break;
-      }
-
-      if (!chunk.hasResultSetMetadata()) {
-        LOG.warn("Chunk doesn't have result metadata so couldn't process the response.");
-        break;
-      }
-
-      for (Row row : chunk.getRowList()) {
-        if (row.getColumnCount() != 1) {
-          LOG.warn("Queried for one column DISTINCTCOUNT but got multiple values");
-          return 0;
-        }
-
-        ColumnMetadata metadata = chunk.getResultSetMetadata().getColumnMetadata(0);
-        org.hypertrace.core.query.service.api.Value columnValue = row.getColumn(0);
-        Value gwValue =
-            QueryAndGatewayDtoConverter.convertToGatewayValueForMetricValue(
-                MetricAggregationFunctionUtil.getValueTypeFromFunction(
-                    distinctCountExpression.getFunction(), attributeMetadataMap),
-                attributeMetadataMap,
-                metadata,
-                columnValue);
-
-        if (gwValue.getValueType() == ValueType.LONG) {
-          return (int)gwValue.getLong();
-        }
-
-        LOG.warn("Non long value for DISTINCTCOUNT");
-      }
-    }
-    return 0;
+    return getTotalEntitiesForMultipleEntityId(requestContext, entitiesRequest);
   }
 
   private int getTotalEntitiesForMultipleEntityId(EntitiesRequestContext requestContext,

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
@@ -206,9 +206,9 @@ public class QueryServiceEntityFetcherTests {
         entityType.name(),
         requestHeaders);
 
-    int total = 5;
     QueryRequest expectedQueryRequest = QueryRequest.newBuilder()
-        .addAggregation(createQsAggregationExpression("DISTINCTCOUNT", "API.id", "DISTINCTCOUNT_entityId_forTotal"))
+        .addSelection(createQsColumnExpression(API_ID_ATTR))
+        .addSelection(createQsAggregationExpression("Count", API_ID_ATTR))
         .setFilter(
             createQsRequestFilter(
                 API_START_TIME_ATTR,
@@ -222,19 +222,17 @@ public class QueryServiceEntityFetcherTests {
                 )
             )
         )
-        .setOffset(0)
-        .setLimit(1)
+        .addGroupBy(createQsColumnExpression(API_ID_ATTR))
+        .setLimit(QueryServiceClient.DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT)
         .build();
 
-
-    List<ResultSetChunk> resultSetChunks = List.of(
-        getResultSetChunk(List.of("DISTINCTCOUNT_entityId_forTotal"), new String[][]{{Integer.toString(total)}})
-    );
+    List<ResultSetChunk> resultSetChunks =
+        List.of(getResultSetChunk(List.of("API.apiId"), new String[][]{ {"apiId1"}, {"apiId2"}}));
 
     when(queryServiceClient.executeQuery(eq(expectedQueryRequest), eq(requestHeaders), eq(500)))
         .thenReturn(resultSetChunks.iterator());
 
-    assertEquals(total, queryServiceEntityFetcher.getTotalEntities(entitiesRequestContext, entitiesRequest));
+    assertEquals(2, queryServiceEntityFetcher.getTotalEntities(entitiesRequestContext, entitiesRequest));
   }
 
   private void mockAttributeMetadataProvider(AttributeScope attributeScope) {


### PR DESCRIPTION
This reverts a minor part of d1659f49898fe3f0c46c24b4d2d359b219ed4ab0. The old behavior is to use groupBy on the entity id and count the records, which is what this commit gets back again.

In the long run, we should get entity total from EDS instead.