### PR TITLE
fix(explore): include rest should not order by

### DIFF
--- a/gateway-service-impl/build.gradle.kts
+++ b/gateway-service-impl/build.gradle.kts
@@ -11,12 +11,11 @@ tasks.test {
 dependencies {
   api(project(":gateway-service-api"))
 
-  implementation("org.hypertrace.core.query.service:query-service-client:0.1.0")
-  implementation("org.hypertrace.core.attribute.service:attribute-service-client:0.1.0")
-  implementation("org.hypertrace.entity.service:entity-service-client:0.1.0")
-  implementation("org.hypertrace.entity.service:entity-service-api:0.1.0")
-  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.1.3")
-  implementation("org.hypertrace.core.documentstore:document-store:0.1.0")
+  implementation("org.hypertrace.core.query.service:query-service-client:0.1.14")
+  implementation("org.hypertrace.core.attribute.service:attribute-service-client:0.3.0")
+  implementation("org.hypertrace.entity.service:entity-service-client:0.1.17")
+  implementation("org.hypertrace.entity.service:entity-service-api:0.1.17")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.2.0")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.2")
 
   // Config

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/TheRestGroupRequestHandler.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/TheRestGroupRequestHandler.java
@@ -80,7 +80,7 @@ class TheRestGroupRequestHandler {
    */
   private ExploreRequest createRequest(
       ExploreRequest originalRequest, ExploreResponse.Builder originalResponse) {
-    // Create a new request copied from the originalRequest but without any group by and set
+    // Create a new request copied from the originalRequest but without any group by, order by and set
     // includeRestGroup set to
     // false. This way we create a query with the same conditions as the original request.
     ExploreRequest.Builder requestBuilder =
@@ -88,6 +88,7 @@ class TheRestGroupRequestHandler {
             .clearGroupBy() // Remove groupBy
             .setIncludeRestGroup(false) // Set includeRestGroup to false.
             .setLimit(1) // Only one row
+            .clearOrderBy() // Remove orderBy
             .setOffset(0); // No offset
 
     // Create a filter to exclude the values in the the groups found in the original request.

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/TheRestGroupRequestHandler.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/TheRestGroupRequestHandler.java
@@ -86,9 +86,9 @@ class TheRestGroupRequestHandler {
     ExploreRequest.Builder requestBuilder =
         ExploreRequest.newBuilder(originalRequest)
             .clearGroupBy() // Remove groupBy
+            .clearOrderBy() // Remove orderBy
             .setIncludeRestGroup(false) // Set includeRestGroup to false.
             .setLimit(1) // Only one row
-            .clearOrderBy() // Remove orderBy
             .setOffset(0); // No offset
 
     // Create a filter to exclude the values in the the groups found in the original request.

--- a/gateway-service-impl/src/test/resources/expected-test-responses/explore/aggregations-with-groupby-and-the-rest.json
+++ b/gateway-service-impl/src/test/resources/expected-test-responses/explore/aggregations-with-groupby-and-the-rest.json
@@ -132,22 +132,6 @@
       "columns": {
         "API_TRACE.serviceName": {
           "valueType": "STRING",
-          "string": "__Other"
-        },
-        "AVG#results/avgLatency:Api.Trace|duration": {
-          "valueType": "DOUBLE",
-          "double": 133.38772
-        },
-        "COUNT#results/countTraces:Api.Trace|apiTraceId": {
-          "valueType": "LONG",
-          "long": "400"
-        }
-      }
-    },
-    {
-      "columns": {
-        "API_TRACE.serviceName": {
-          "valueType": "STRING",
           "string": "userservice"
         },
         "AVG#results/avgLatency:Api.Trace|duration": {
@@ -173,6 +157,22 @@
         "COUNT#results/countTraces:Api.Trace|apiTraceId": {
           "valueType": "LONG",
           "long": "755"
+        }
+      }
+    },
+    {
+      "columns": {
+        "API_TRACE.serviceName": {
+          "valueType": "STRING",
+          "string": "__Other"
+        },
+        "AVG#results/avgLatency:Api.Trace|duration": {
+          "valueType": "DOUBLE",
+          "double": 133.38772
+        },
+        "COUNT#results/countTraces:Api.Trace|apiTraceId": {
+          "valueType": "LONG",
+          "long": "400"
         }
       }
     }

--- a/gateway-service-impl/src/test/resources/expected-test-responses/explore/aggregations-with-multiple-groupbys-and-the-rest.json
+++ b/gateway-service-impl/src/test/resources/expected-test-responses/explore/aggregations-with-multiple-groupbys-and-the-rest.json
@@ -164,26 +164,6 @@
       "columns": {
         "API_TRACE.serviceName": {
           "valueType": "STRING",
-          "string": "__Other"
-        },
-        "API_TRACE.apiName": {
-          "valueType": "STRING",
-          "string": "__Other"
-        },
-        "AVG#results/avgLatency:Api.Trace|duration": {
-          "valueType": "DOUBLE",
-          "double": 133.38772
-        },
-        "COUNT#results/countTraces:Api.Trace|apiTraceId": {
-          "valueType": "LONG",
-          "long": "400"
-        }
-      }
-    },
-    {
-      "columns": {
-        "API_TRACE.serviceName": {
-          "valueType": "STRING",
           "string": "dataservice"
         },
         "API_TRACE.apiName": {
@@ -217,6 +197,26 @@
         "COUNT#results/countTraces:Api.Trace|apiTraceId": {
           "valueType": "LONG",
           "long": "755"
+        }
+      }
+    },
+    {
+      "columns": {
+        "API_TRACE.serviceName": {
+          "valueType": "STRING",
+          "string": "__Other"
+        },
+        "API_TRACE.apiName": {
+          "valueType": "STRING",
+          "string": "__Other"
+        },
+        "AVG#results/avgLatency:Api.Trace|duration": {
+          "valueType": "DOUBLE",
+          "double": 133.38772
+        },
+        "COUNT#results/countTraces:Api.Trace|apiTraceId": {
+          "valueType": "LONG",
+          "long": "400"
         }
       }
     }

--- a/gateway-service-impl/src/test/resources/query-service-requests-and-responses/explore/aggregations-with-groupby-and-the-rest.json
+++ b/gateway-service-impl/src/test/resources/query-service-requests-and-responses/explore/aggregations-with-groupby-and-the-rest.json
@@ -499,23 +499,6 @@
           }
         }
       ],
-      "orderBy": [
-        {
-          "expression": {
-            "function": {
-              "functionName": "COUNT",
-              "arguments": [
-                {
-                  "columnIdentifier": {
-                    "columnName": "API_TRACE.apiTraceId"
-                  }
-                }
-              ],
-              "alias": "COUNT#COUNT:Api.Trace|apiTraceId"
-            }
-          }
-        }
-      ],
       "limit": 1
     },
     "response": {

--- a/gateway-service-impl/src/test/resources/query-service-requests-and-responses/explore/aggregations-with-multiple-groupbys-and-the-rest.json
+++ b/gateway-service-impl/src/test/resources/query-service-requests-and-responses/explore/aggregations-with-multiple-groupbys-and-the-rest.json
@@ -930,23 +930,6 @@
           }
         }
       ],
-      "orderBy": [
-        {
-          "expression": {
-            "function": {
-              "functionName": "COUNT",
-              "arguments": [
-                {
-                  "columnIdentifier": {
-                    "columnName": "API_TRACE.apiTraceId"
-                  }
-                }
-              ],
-              "alias": "COUNT#COUNT:Api.Trace|apiTraceId"
-            }
-          }
-        }
-      ],
       "limit": 1
     },
     "response": {

--- a/gateway-service/src/main/resources/configs/common/application.conf
+++ b/gateway-service/src/main/resources/configs/common/application.conf
@@ -38,7 +38,12 @@ interaction.config = [
   }
 ]
 
-timestamp.config = []
+timestamp.config = [
+  {
+    scope = DOMAIN_EVENT
+    timestamp = timestamp
+  }
+]
 
 domainobject.config = [
   {

--- a/gateway-service/src/main/resources/configs/common/application.conf
+++ b/gateway-service/src/main/resources/configs/common/application.conf
@@ -38,12 +38,7 @@ interaction.config = [
   }
 ]
 
-timestamp.config = [
-  {
-    scope = DOMAIN_EVENT
-    timestamp = timestamp
-  }
-]
+timestamp.config = []
 
 domainobject.config = [
   {


### PR DESCRIPTION
Include Rest only outputs a single aggregated result as Others. Having an order by without group by is not supported by the current OLAP store (Pinot)