### PR TITLE
Add name for the port in service

### DIFF
--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.containerPortName }}
-      name: grpc-{{ .Chart.Name }}
+      name: {{ .Values.containerPortName }}-{{ .Chart.Name }}
   selector:
     {{- toYaml .Values.serviceSelectorLabels | nindent 4 }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -9,5 +9,6 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.containerPortName }}
+      name: grpc-{{ .Chart.Name }}
   selector:
     {{- toYaml .Values.serviceSelectorLabels | nindent 4 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -12,7 +12,7 @@ imagePullSecrets: []
 
 containerPort: 50071
 containerAdminPort: 50072
-containerPortName: http
+containerPortName: grpc
 
 env: []
 


### PR DESCRIPTION
Istio does protocol selection by looking at
the prefix of port name defined in the service.
In case istio is not able to detect the protocol,
it treats the traffic as plain tcp traffic.