### PR TITLE
Update the port for liveness probe

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             initialDelaySeconds: {{ int .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ int .Values.livenessProbe.periodSeconds }}
             tcpSocket:
-              port: http
+              port: {{ .Values.containerPortName }}
           readinessProbe:
             initialDelaySeconds: {{ int .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ int .Values.readinessProbe.periodSeconds }}


### PR DESCRIPTION
Portname was updated to grpc by defining `containerPortName` in values.yaml. Updated the liveness probe with the new value.