### PR TITLE
Don't set limit for the entities query when the query to OLAP

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/SelectionAndFilterNode.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/SelectionAndFilterNode.java
@@ -1,8 +1,6 @@
 package org.hypertrace.gateway.service.entity.query;
 
-import java.util.List;
 import org.hypertrace.gateway.service.entity.query.visitor.Visitor;
-import org.hypertrace.gateway.service.v1.common.OrderByExpression;
 
 public class SelectionAndFilterNode implements QueryNode {
 

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
@@ -83,7 +83,7 @@ public class QueryServiceEntityFetcherTests {
     List<OrderByExpression> orderByExpressions = List.of(buildOrderByExpression(API_ID_ATTR));
     long startTime = 0L;
     long endTime = 10L;
-    int limit = 10000;
+    int limit = 10;
     int offset = 0;
     String tenantId = "TENANT_ID";
     Map<String, String> requestHeaders = Map.of("x-tenant-id", tenantId);
@@ -130,7 +130,9 @@ public class QueryServiceEntityFetcherTests {
         .addGroupBy(createQsColumnExpression(API_NAME_ATTR))
         .addOrderBy(createQsOrderBy(createQsColumnExpression(API_ID_ATTR), SortOrder.ASC))
         .setOffset(offset)
-        .setLimit(limit)
+        // Though the limit on entities request is less, since there are multiple columns in the
+        // groupBy, the limit will be set to the default from query service.
+        .setLimit(QueryServiceClient.DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT)
         .build();
 
     List<ResultSetChunk> resultSetChunks = List.of(
@@ -191,7 +193,6 @@ public class QueryServiceEntityFetcherTests {
             .setEntityType(entityType.name())
             .setStartTimeMillis(startTime)
             .setEndTimeMillis(endTime)
-            .addSelection(buildExpression(API_NAME_ATTR))
             .addSelection(buildAggregateExpression(API_DURATION_ATTR, FunctionType.AVG, "AVG_API.duration", List.of()))
             .addTimeAggregation(buildTimeAggregation(30, API_NUM_CALLS_ATTR, FunctionType.SUM, "SUM_API.numCalls", List.of()))
             .setFilter(generateEQFilter(API_DISCOVERY_STATE_ATTR, "DISCOVERED"))

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
@@ -193,6 +193,7 @@ public class QueryServiceEntityFetcherTests {
             .setEntityType(entityType.name())
             .setStartTimeMillis(startTime)
             .setEndTimeMillis(endTime)
+            .addSelection(buildExpression(API_NAME_ATTR))
             .addSelection(buildAggregateExpression(API_DURATION_ATTR, FunctionType.AVG, "AVG_API.duration", List.of()))
             .addTimeAggregation(buildTimeAggregation(30, API_NUM_CALLS_ATTR, FunctionType.SUM, "SUM_API.numCalls", List.of()))
             .setFilter(generateEQFilter(API_DISCOVERY_STATE_ATTR, "DISCOVERED"))

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
@@ -83,7 +83,7 @@ public class QueryServiceEntityFetcherTests {
     List<OrderByExpression> orderByExpressions = List.of(buildOrderByExpression(API_ID_ATTR));
     long startTime = 0L;
     long endTime = 10L;
-    int limit = 10;
+    int limit = 10000;
     int offset = 0;
     String tenantId = "TENANT_ID";
     Map<String, String> requestHeaders = Map.of("x-tenant-id", tenantId);

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/EntityServiceTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/EntityServiceTest.java
@@ -176,7 +176,7 @@ public class EntityServiceTest extends AbstractGatewayServiceTest {
         .setFilter(queryServiceFilter)
         .addGroupBy(createQsColumnExpression("API.apiId"))
         .addGroupBy(createQsColumnExpression("API.apiName", "API Name"))
-        .setLimit(10000)
+        .setLimit(QueryServiceClient.DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT)
         .build();
     when(queryServiceClient.executeQuery(eq(expectedQueryRequest), any(), Mockito.anyInt()))
         .thenReturn(

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/EntityServiceTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/EntityServiceTest.java
@@ -176,7 +176,7 @@ public class EntityServiceTest extends AbstractGatewayServiceTest {
         .setFilter(queryServiceFilter)
         .addGroupBy(createQsColumnExpression("API.apiId"))
         .addGroupBy(createQsColumnExpression("API.apiName", "API Name"))
-        .setLimit(2)
+        .setLimit(10000)
         .build();
     when(queryServiceClient.executeQuery(eq(expectedQueryRequest), any(), Mockito.anyInt()))
         .thenReturn(


### PR DESCRIPTION
is grouping by multiple columns since that leads to wrong results.
For now we set limit to a higher value in those cases.