### PR TITLE
Fixing a bug in merging data from multiple sources in query execution visitor.

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/SelectionAndFilterNode.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/SelectionAndFilterNode.java
@@ -34,7 +34,9 @@ public class SelectionAndFilterNode implements QueryNode {
   @Override
   public String toString() {
     return "SelectionAndFilterNode{"
-        + "limit="
+        + "source="
+        + source
+        + ", limit="
         + limit
         + ", offset="
         + offset

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/SelectionNode.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/SelectionNode.java
@@ -59,6 +59,8 @@ public class SelectionNode implements QueryNode {
         + aggMetricSelectionSources
         + ", timeSeriesSelectionSources="
         + timeSeriesSelectionSources
+        + ", childNode="
+        + childNode
         + '}';
   }
 

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/SortAndPaginateNode.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/SortAndPaginateNode.java
@@ -51,6 +51,8 @@ public class SortAndPaginateNode implements QueryNode {
         + offset
         + ", orderByExpressionList="
         + orderByExpressionList
+        + ", childNode="
+        + childNode
         + '}';
   }
 }

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitor.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitor.java
@@ -230,8 +230,13 @@ public class ExecutionVisitor implements Visitor<EntityFetcherResponse> {
     EntityFetcherResponse currentResponse =
         resultMapList.stream().reduce(new EntityFetcherResponse(), (r1, r2) -> union(Arrays.asList(r1, r2)));
 
-    // Intersect the response from this source with the response from the child.
-    return intersect(Arrays.asList(childNodeResponse, currentResponse));
+    // If the child node was a NoOp, just return the current response.
+    if (selectionNode.getChildNode() instanceof NoOpNode) {
+      return currentResponse;
+    } else {
+      // Intersect the response from this source with the response from the child.
+      return intersect(Arrays.asList(childNodeResponse, currentResponse));
+    }
   }
 
   Filter constructFilterFromChildNodesResult(EntityFetcherResponse result) {

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitor.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitor.java
@@ -142,18 +142,18 @@ public class ExecutionVisitor implements Visitor<EntityFetcherResponse> {
 
   @Override
   public EntityFetcherResponse visit(SelectionNode selectionNode) {
-    EntityFetcherResponse result = selectionNode.getChildNode().acceptVisitor(this);
+    EntityFetcherResponse childNodeResponse = selectionNode.getChildNode().acceptVisitor(this);
 
     // If the result was empty when the filter is non-empty, it means no entities matched the filter
     // and hence no need to do any more follow up calls.
-    if (result.isEmpty()
+    if (childNodeResponse.isEmpty()
         && !Filter.getDefaultInstance().equals(executionContext.getEntitiesRequest().getFilter())) {
       LOG.debug("No results matched the filter so not fetching aggregate/timeseries metrics.");
-      return result;
+      return childNodeResponse;
     }
 
     // Construct the filter from the child nodes result
-    Filter filter = constructFilterFromChildNodesResult(result);
+    Filter filter = constructFilterFromChildNodesResult(childNodeResponse);
     // Select attributes, metric aggregations and time-series data from corresponding sources
     List<EntityFetcherResponse> resultMapList = new ArrayList<>();
     // if data are coming from multiple sources, then, get entities and aggregated metrics
@@ -226,7 +226,12 @@ public class ExecutionVisitor implements Visitor<EntityFetcherResponse> {
                   return entityFetcher.getTimeAggregatedMetrics(requestContext, request);
                 })
             .collect(Collectors.toList()));
-    return resultMapList.stream().reduce(result, (r1, r2) -> union(Arrays.asList(r1, r2)));
+    // Union all the responses from this single source first.
+    EntityFetcherResponse currentResponse =
+        resultMapList.stream().reduce(new EntityFetcherResponse(), (r1, r2) -> union(Arrays.asList(r1, r2)));
+
+    // Intersect the response from this source with the response from the child.
+    return intersect(Arrays.asList(childNodeResponse, currentResponse));
   }
 
   Filter constructFilterFromChildNodesResult(EntityFetcherResponse result) {

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/EntityServiceTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/EntityServiceTest.java
@@ -37,6 +37,8 @@ import org.hypertrace.gateway.service.entity.config.DomainObjectConfigs;
 import org.hypertrace.gateway.service.entity.config.LogConfig;
 import org.hypertrace.gateway.service.v1.common.ColumnIdentifier;
 import org.hypertrace.gateway.service.v1.common.Expression;
+import org.hypertrace.gateway.service.v1.common.LiteralConstant;
+import org.hypertrace.gateway.service.v1.common.Operator;
 import org.hypertrace.gateway.service.v1.entity.EntitiesRequest;
 import org.hypertrace.gateway.service.v1.entity.EntitiesResponse;
 import org.hypertrace.gateway.service.v1.entity.Entity;
@@ -249,6 +251,11 @@ public class EntityServiceTest extends AbstractGatewayServiceTest {
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("API")
+            .setFilter(org.hypertrace.gateway.service.v1.common.Filter.newBuilder()
+                .setOperator(Operator.IN)
+                .setLhs(getExpressionFor("API.httpMethod", "API Http method"))
+                .setRhs(getStringListLiteral(List.of("GET", "POST")))
+            )
             .addSelection(getExpressionFor("API.apiId", "API Id"))
             .addSelection(getExpressionFor("API.apiName", "API Name"))
             .addSelection(getExpressionFor("API.httpMethod", "API Http method"))
@@ -256,14 +263,23 @@ public class EntityServiceTest extends AbstractGatewayServiceTest {
     EntitiesResponse response = entityService.getEntities(TENANT_ID, entitiesRequest, Map.of());
     Assertions.assertNotNull(response);
     Assertions.assertEquals(2, response.getTotal());
-    Entity entity1 = response.getEntity(0);
-    Assertions.assertEquals("apiId1", entity1.getAttributeMap().get("API.apiId").getString());
-    Assertions.assertEquals("/login", entity1.getAttributeMap().get("API.apiName").getString());
-    Assertions.assertEquals("GET", entity1.getAttributeMap().get("API.httpMethod").getString());
-    Entity entity2 = response.getEntity(1);
-    Assertions.assertEquals("apiId2", entity2.getAttributeMap().get("API.apiId").getString());
-    Assertions.assertEquals("/checkout", entity2.getAttributeMap().get("API.apiName").getString());
-    Assertions.assertEquals("POST", entity2.getAttributeMap().get("API.httpMethod").getString());
+    for (Entity entity: response.getEntityList()) {
+      if ("apiId1".equals(entity.getAttributeMap().get("API.apiId").getString())) {
+        Assertions.assertEquals("/login", entity.getAttributeMap().get("API.apiName").getString());
+        Assertions.assertEquals("GET", entity.getAttributeMap().get("API.httpMethod").getString());
+      } else if ("apiId2".equals(entity.getAttributeMap().get("API.apiId").getString())) {
+        Assertions.assertEquals("/checkout", entity.getAttributeMap().get("API.apiName").getString());
+        Assertions.assertEquals("POST", entity.getAttributeMap().get("API.httpMethod").getString());
+      }
+    }
+  }
+
+  private Expression getStringListLiteral(List<String> values) {
+    return Expression.newBuilder().setLiteral(
+        LiteralConstant.newBuilder().setValue(
+            org.hypertrace.gateway.service.v1.common.Value.newBuilder()
+                .setValueType(org.hypertrace.gateway.service.v1.common.ValueType.STRING_ARRAY)
+                .addAllStringArray(values))).build();
   }
 
   private Expression getExpressionFor(String columnName, String alias) {

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilderTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilderTest.java
@@ -32,6 +32,7 @@ import org.hypertrace.gateway.service.common.RequestContext;
 import org.hypertrace.gateway.service.entity.EntitiesRequestContext;
 import org.hypertrace.gateway.service.entity.config.DomainObjectConfigs;
 import org.hypertrace.gateway.service.entity.query.visitor.OptimizingVisitor;
+import org.hypertrace.gateway.service.entity.query.visitor.PrintVisitor;
 import org.hypertrace.gateway.service.v1.common.Filter;
 import org.hypertrace.gateway.service.v1.common.FunctionType;
 import org.hypertrace.gateway.service.v1.common.Operator;
@@ -737,6 +738,38 @@ public class ExecutionTreeBuilderTest {
         ((SelectionNode) secondChild)
             .getAttrSelectionSources()
             .contains(AttributeSource.EDS.name()));
+  }
+
+  @Test
+  public void test_build_selectAttributeWithFiltersWithDifferentSource_shouldCreateDifferentNode() {
+    EntitiesRequest entitiesRequest =
+        EntitiesRequest.newBuilder()
+            .setEntityType(AttributeScope.API.name())
+            .setFilter(generateEQFilter(API_PATTERN_ATTR, "/login"))
+            .addSelection(buildExpression(API_NAME_ATTR))
+            .addSelection(
+                buildAggregateExpression(API_NUM_CALLS_ATTR,
+                    FunctionType.SUM,
+                    "SUM_numCalls",
+                    List.of()))
+            .build();
+    EntitiesRequestContext entitiesRequestContext =
+        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", new HashMap<>());
+    ExecutionContext executionContext =
+        ExecutionContext.from(attributeMetadataProvider, entitiesRequest, entitiesRequestContext);
+    ExecutionTreeBuilder executionTreeBuilder = new ExecutionTreeBuilder(executionContext);
+    QueryNode executionTree = executionTreeBuilder.build();
+    assertNotNull(executionTree);
+    assertTrue(executionTree instanceof SelectionNode);
+    assertTrue(
+        ((SelectionNode) executionTree)
+            .getAggMetricSelectionSources()
+            .contains(AttributeSource.QS.name()));
+    QueryNode firstChild = ((SelectionNode) executionTree).getChildNode();
+    assertTrue(firstChild instanceof SortAndPaginateNode);
+    QueryNode secondChild = ((SortAndPaginateNode) firstChild).getChildNode();
+    assertTrue(secondChild instanceof DataFetcherNode);
+    assertEquals(AttributeSource.EDS.name(), ((DataFetcherNode) secondChild).getSource());
   }
 
   private void mockDomainObjectConfigs() {

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitorTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitorTest.java
@@ -10,10 +10,12 @@ import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUt
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.getStringValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -36,6 +38,7 @@ import org.hypertrace.gateway.service.common.datafetcher.QueryServiceEntityFetch
 import org.hypertrace.gateway.service.entity.EntitiesRequestContext;
 import org.hypertrace.gateway.service.entity.EntityKey;
 import org.hypertrace.gateway.service.entity.EntityQueryHandlerRegistry;
+import org.hypertrace.gateway.service.entity.query.DataFetcherNode;
 import org.hypertrace.gateway.service.entity.query.ExecutionContext;
 import org.hypertrace.gateway.service.entity.query.NoOpNode;
 import org.hypertrace.gateway.service.entity.query.PaginateOnlyNode;
@@ -43,6 +46,7 @@ import org.hypertrace.gateway.service.entity.query.SelectionAndFilterNode;
 import org.hypertrace.gateway.service.entity.query.SelectionNode;
 import org.hypertrace.gateway.service.entity.query.TotalFetcherNode;
 import org.hypertrace.gateway.service.v1.common.ColumnIdentifier;
+import org.hypertrace.gateway.service.v1.common.DomainEntityType;
 import org.hypertrace.gateway.service.v1.common.Expression;
 import org.hypertrace.gateway.service.v1.common.Filter;
 import org.hypertrace.gateway.service.v1.common.FunctionType;
@@ -74,7 +78,7 @@ public class ExecutionVisitorTest {
   private static final String API_DURATION_ATTR = "API.duration";
   private static final String API_DISCOVERY_STATE = "API.apiDiscoveryState";
 
-  private EntityFetcherResponse result1 =
+  private final EntityFetcherResponse result1 =
       new EntityFetcherResponse(
           Map.of(
               EntityKey.of("id1"),
@@ -83,21 +87,21 @@ public class ExecutionVisitorTest {
                   Entity.newBuilder().putAttribute("key12", getStringValue("value12")),
               EntityKey.of("id3"),
                   Entity.newBuilder().putAttribute("key13", getStringValue("value13"))));
-  private EntityFetcherResponse result2 =
+  private final EntityFetcherResponse result2 =
       new EntityFetcherResponse(
           Map.of(
               EntityKey.of("id1"),
                   Entity.newBuilder().putAttribute("key21", getStringValue("value21")),
               EntityKey.of("id2"),
                   Entity.newBuilder().putAttribute("key22", getStringValue("value22"))));
-  private EntityFetcherResponse result3 =
+  private final EntityFetcherResponse result3 =
       new EntityFetcherResponse(
           Map.of(
               EntityKey.of("id1"),
                   Entity.newBuilder().putAttribute("key31", getStringValue("value31")),
               EntityKey.of("id3"),
                   Entity.newBuilder().putAttribute("key33", getStringValue("value33"))));
-  private EntityFetcherResponse result4 =
+  private final EntityFetcherResponse result4 =
       new EntityFetcherResponse(
           Map.of(
               EntityKey.of("id4"),
@@ -381,6 +385,34 @@ public class ExecutionVisitorTest {
     SelectionAndFilterNode selectionAndFilterNode = new SelectionAndFilterNode("QS", limit, offset);
 
     compareEntityFetcherResponses(entityFetcherResponse, executionVisitor.visit(selectionAndFilterNode));
+  }
+
+  /**
+   * A simple test to verify that the responses are merged properly when multiple data sources are involved in
+   * entities query.
+   */
+  @Test
+  public void testSelectionAndFilterWithMultipleSources() {
+    ExecutionVisitor executionVisitor =
+        spy(new ExecutionVisitor(executionContext, entityQueryHandlerRegistry));
+
+    // Make the first query, which involves a filter to EDS.
+    DataFetcherNode dataFetcherNode = new DataFetcherNode("EDS", generateEQFilter(API_DISCOVERY_STATE, "DISCOVERED"));
+
+    // Let the EDS query return result4, which has one entity in it
+    when(entityDataServiceEntityFetcher.getEntities(any(), any())).thenReturn(result4);
+
+    SelectionNode selectionNode = new SelectionNode.Builder(dataFetcherNode)
+        .setAttrSelectionSources(Set.of(QS_SOURCE))
+        .build();
+    mockExecutionContext(Set.of(QS_SOURCE), Set.of(), Map.of(QS_SOURCE, List.of(buildExpression(API_NAME_ATTR))), Map.of());
+
+    // When the query is made to Query service, don't return any response.
+    when(queryServiceEntityFetcher.getEntities(any(), any())).thenReturn(new EntityFetcherResponse());
+    EntityFetcherResponse response = executionVisitor.visit(selectionNode);
+
+    // The final result should be empty because query service didn't return anything.
+    assertTrue(response.getEntityKeyBuilderMap().isEmpty());
   }
 
   @Test
@@ -697,6 +729,33 @@ public class ExecutionVisitorTest {
     executionVisitor.visit(selectionNode);
     verify(entityDataServiceEntityFetcher).getEntities(any(), any());
     verify(queryServiceEntityFetcher).getAggregatedMetrics(any(), any());
+  }
+
+  @Test
+  public void test_visitSelectionNode_nonEmptyFilter_emptyResult() {
+    // Create a request with non-empty filter.
+    EntitiesRequest entitiesRequest =
+        EntitiesRequest.newBuilder()
+            .setEntityType(DomainEntityType.API.name())
+            .setStartTimeMillis(10)
+            .setEndTimeMillis(20)
+            .addSelection(buildExpression(API_NAME_ATTR))
+            .setFilter(generateEQFilter(API_DISCOVERY_STATE, "DISCOVERED"))
+            .build();
+    ExecutionVisitor executionVisitor =
+        spy(new ExecutionVisitor(executionContext, entityQueryHandlerRegistry));
+    when(executionContext.getEntitiesRequest()).thenReturn(entitiesRequest);
+
+    // Selection node with NoOp child, to short-circuit the call to first service.
+    SelectionNode selectionNode = new SelectionNode.Builder(new NoOpNode())
+        .setAttrSelectionSources(Set.of(EDS_SOURCE))
+        .setAggMetricSelectionSources(Set.of(QS_SOURCE))
+        .build();
+
+    EntityFetcherResponse response = executionVisitor.visit(selectionNode);
+    Assertions.assertTrue(response.isEmpty());
+    verify(queryServiceEntityFetcher, never()).getEntities(any(), any());
+    verify(queryServiceEntityFetcher, never()).getAggregatedMetrics(any(), any());
   }
 
   private MetricSeries getMockMetricSeries(int period, String aggregation) {


### PR DESCRIPTION
Currently, though query filter between two different data sources is `AND`ed, the results are unioned. This PR fixes that by converting them into intersection.