### PR TITLE
Timestamp filter refactoring to fix time range filtering bugs in entity queries.

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/converters/QueryAndGatewayDtoConverter.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/converters/QueryAndGatewayDtoConverter.java
@@ -392,10 +392,10 @@ public class QueryAndGatewayDtoConverter {
     return builder.build();
   }
 
-  public static Filter convertToQueryFilter(
+  public static Filter.Builder convertToQueryFilter(
       org.hypertrace.gateway.service.v1.common.Filter filter) {
     if (filter.equals(org.hypertrace.gateway.service.v1.common.Filter.getDefaultInstance())) {
-      return Filter.getDefaultInstance();
+      return Filter.newBuilder();
     }
     Filter.Builder builder = Filter.newBuilder();
     builder.setOperator(convertOperator(filter.getOperator()));
@@ -410,7 +410,7 @@ public class QueryAndGatewayDtoConverter {
       builder.setRhs(convertToQueryExpression(filter.getRhs()));
     }
 
-    return builder.build();
+    return builder;
   }
 
   public static Filter.Builder addTimeFilterAndConvertToQueryFilter(

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcher.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcher.java
@@ -285,6 +285,11 @@ public class QueryServiceEntityFetcher implements IEntityFetcher {
       LOG.debug("Sending Query to Query Service ======== \n {}", queryRequest);
     }
 
+    try {
+      System.out.println("Actual: " + JsonFormat.printer().omittingInsignificantWhitespace().print(queryRequest));
+    } catch (InvalidProtocolBufferException e) {
+      e.printStackTrace();
+    }
     Iterator<ResultSetChunk> resultSetChunkIterator =
         queryServiceClient.executeQuery(queryRequest, requestContext.getHeaders(), requestTimeout);
 

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcher.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcher.java
@@ -724,8 +724,7 @@ public class QueryServiceEntityFetcher implements IEntityFetcher {
   }
 
   /**
-   * - Adds the time range to the filter - Adds a non null filter on entity id - Converts it to the
-   * query service filter
+   * Converts the filter in the given request to the query service filter and adds a non null filter on entity id.
    */
   private Filter.Builder constructQueryServiceFilter(EntitiesRequest entitiesRequest, List<String> entityIdAttributes) {
     Filter.Builder filterBuilder = convertToQueryFilter(entitiesRequest.getFilter());

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcher.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcher.java
@@ -15,8 +15,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.util.JsonFormat;
 import org.apache.commons.lang3.StringUtils;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
 import org.hypertrace.core.query.service.api.ColumnMetadata;
@@ -103,11 +101,6 @@ public class QueryServiceEntityFetcher implements IEntityFetcher {
       LOG.debug("Sending Query to Query Service ======== \n {}", queryRequest);
     }
 
-    try {
-      System.out.println("actual: " + JsonFormat.printer().omittingInsignificantWhitespace().print(queryRequest));
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
-    }
     Iterator<ResultSetChunk> resultSetChunkIterator =
         queryServiceClient.executeQuery(queryRequest, requestContext.getHeaders(),
             requestTimeout);
@@ -285,11 +278,6 @@ public class QueryServiceEntityFetcher implements IEntityFetcher {
       LOG.debug("Sending Query to Query Service ======== \n {}", queryRequest);
     }
 
-    try {
-      System.out.println("Actual: " + JsonFormat.printer().omittingInsignificantWhitespace().print(queryRequest));
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
-    }
     Iterator<ResultSetChunk> resultSetChunkIterator =
         queryServiceClient.executeQuery(queryRequest, requestContext.getHeaders(), requestTimeout);
 
@@ -543,7 +531,7 @@ public class QueryServiceEntityFetcher implements IEntityFetcher {
       long periodSecs = Duration.of(period.getValue(), unit).getSeconds();
       QueryRequest request =
           buildTimeSeriesQueryRequest(
-              entitiesRequest, requestContext, periodSecs, batch, idColumns, timeColumn);
+              entitiesRequest, periodSecs, batch, idColumns, timeColumn);
 
       if (LOG.isDebugEnabled()) {
         LOG.debug(
@@ -686,7 +674,6 @@ public class QueryServiceEntityFetcher implements IEntityFetcher {
 
   private QueryRequest buildTimeSeriesQueryRequest(
       EntitiesRequest entitiesRequest,
-      EntitiesRequestContext entitiesRequestContext,
       long periodSecs,
       List<TimeAggregation> timeAggregationBatch,
       List<String> idColumns,
@@ -702,13 +689,6 @@ public class QueryServiceEntityFetcher implements IEntityFetcher {
             .setStartTimeMillis(alignedStartTime)
             .setEndTimeMillis(alignedEndTime)
             .build();
-    EntitiesRequestContext timeAlignedEntitiesRequestContext =
-        new EntitiesRequestContext(
-            entitiesRequestContext.getTenantId(),
-            alignedStartTime,
-            alignedEndTime,
-            entitiesRequestContext.getEntityType(),
-            entitiesRequestContext.getHeaders());
 
     QueryRequest.Builder builder = QueryRequest.newBuilder();
     timeAggregationBatch.forEach(

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/transformer/RequestPreProcessor.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/transformer/RequestPreProcessor.java
@@ -29,6 +29,7 @@ import org.hypertrace.gateway.service.entity.EntityKey;
 import org.hypertrace.gateway.service.entity.config.DomainObjectFilter;
 import org.hypertrace.gateway.service.entity.config.DomainObjectMapping;
 import org.hypertrace.gateway.service.trace.TraceScope;
+import org.hypertrace.gateway.service.v1.common.ColumnIdentifier;
 import org.hypertrace.gateway.service.v1.common.Expression;
 import org.hypertrace.gateway.service.v1.common.Expression.ValueCase;
 import org.hypertrace.gateway.service.v1.common.Filter;
@@ -109,16 +110,37 @@ public class RequestPreProcessor {
         transformFilter(attributeIdMappings, originalRequest.getFilter(), context);
     Filter filter = mergeFilters(filterToInject, transformedFilter);
 
+    // Convert the time range into a filter and set it on the request so that all downstream
+    // components needn't treat it specially.
+    String timestampAttributeId = AttributeMetadataUtil.getTimestampAttributeId(
+        attributeMetadataProvider, context, originalRequest.getEntityType());
+
+    Filter.Builder filterBuilder = Filter.newBuilder()
+        .setOperator(AND)
+        .addChildFilter(getTimestampFilter(timestampAttributeId, Operator.GE, originalRequest.getStartTimeMillis()))
+        .addChildFilter(getTimestampFilter(timestampAttributeId, Operator.LT, originalRequest.getEndTimeMillis()));
+    if (!Filter.getDefaultInstance().equals(filter)) {
+      filterBuilder.addChildFilter(filter);
+    }
+
     // Apply the scope filter at the end.
     filter = scopeFilterConfigs.createScopeFilter(
             originalRequest.getEntityType(),
-            filter,
+            filterBuilder.build(),
             attributeMetadataProvider,
             context);
 
     entitiesRequestBuilder.setFilter(filter);
 
     return entitiesRequestBuilder.build();
+  }
+
+  private Filter getTimestampFilter(String colName, Operator operator, long timestamp) {
+    return Filter.newBuilder().setOperator(operator)
+        .setLhs(Expression.newBuilder().setColumnIdentifier(ColumnIdentifier.newBuilder().setColumnName(colName)))
+        .setRhs(Expression.newBuilder().setLiteral(
+            LiteralConstant.newBuilder().setValue(Value.newBuilder().setValueType(ValueType.LONG).setLong(timestamp))))
+        .build();
   }
 
   /**

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilder.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilder.java
@@ -4,7 +4,6 @@ import static org.hypertrace.core.attribute.service.v1.AttributeSource.EDS;
 import static org.hypertrace.core.attribute.service.v1.AttributeSource.QS;
 
 import com.google.common.annotations.VisibleForTesting;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilder.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilder.java
@@ -4,6 +4,7 @@ import static org.hypertrace.core.attribute.service.v1.AttributeSource.EDS;
 import static org.hypertrace.core.attribute.service.v1.AttributeSource.QS;
 
 import com.google.common.annotations.VisibleForTesting;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/SelectionAndFilterNode.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/SelectionAndFilterNode.java
@@ -34,7 +34,9 @@ public class SelectionAndFilterNode implements QueryNode {
   @Override
   public String toString() {
     return "SelectionAndFilterNode{"
-        + "limit="
+        + "source="
+        + source
+        + ", limit="
         + limit
         + ", offset="
         + offset

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/SelectionNode.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/SelectionNode.java
@@ -59,6 +59,8 @@ public class SelectionNode implements QueryNode {
         + aggMetricSelectionSources
         + ", timeSeriesSelectionSources="
         + timeSeriesSelectionSources
+        + ", childNode="
+        + childNode
         + '}';
   }
 

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/SortAndPaginateNode.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/SortAndPaginateNode.java
@@ -51,6 +51,8 @@ public class SortAndPaginateNode implements QueryNode {
         + offset
         + ", orderByExpressionList="
         + orderByExpressionList
+        + ", childNode="
+        + childNode
         + '}';
   }
 }

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionContextBuilderVisitor.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionContextBuilderVisitor.java
@@ -16,7 +16,7 @@ import org.hypertrace.gateway.service.entity.query.TotalFetcherNode;
  */
 public class ExecutionContextBuilderVisitor implements Visitor<Void> {
 
-  private ExecutionContext executionContext;
+  private final ExecutionContext executionContext;
 
   public ExecutionContextBuilderVisitor(ExecutionContext executionContext) {
     this.executionContext = executionContext;

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitor.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitor.java
@@ -142,18 +142,18 @@ public class ExecutionVisitor implements Visitor<EntityFetcherResponse> {
 
   @Override
   public EntityFetcherResponse visit(SelectionNode selectionNode) {
-    EntityFetcherResponse result = selectionNode.getChildNode().acceptVisitor(this);
+    EntityFetcherResponse childNodeResponse = selectionNode.getChildNode().acceptVisitor(this);
 
     // If the result was empty when the filter is non-empty, it means no entities matched the filter
     // and hence no need to do any more follow up calls.
-    if (result.isEmpty()
+    if (childNodeResponse.isEmpty()
         && !Filter.getDefaultInstance().equals(executionContext.getEntitiesRequest().getFilter())) {
       LOG.debug("No results matched the filter so not fetching aggregate/timeseries metrics.");
-      return result;
+      return childNodeResponse;
     }
 
     // Construct the filter from the child nodes result
-    Filter filter = constructFilterFromChildNodesResult(result);
+    Filter filter = constructFilterFromChildNodesResult(childNodeResponse);
     // Select attributes, metric aggregations and time-series data from corresponding sources
     List<EntityFetcherResponse> resultMapList = new ArrayList<>();
     // if data are coming from multiple sources, then, get entities and aggregated metrics
@@ -226,7 +226,12 @@ public class ExecutionVisitor implements Visitor<EntityFetcherResponse> {
                   return entityFetcher.getTimeAggregatedMetrics(requestContext, request);
                 })
             .collect(Collectors.toList()));
-    return resultMapList.stream().reduce(result, (r1, r2) -> union(Arrays.asList(r1, r2)));
+    // Union all the responses from this single source first.
+    EntityFetcherResponse currentResponse =
+        resultMapList.stream().reduce(new EntityFetcherResponse(), (r1, r2) -> union(Arrays.asList(r1, r2)));
+
+    // Intersect the response from this source with the response from the child.
+    return intersect(Arrays.asList(childNodeResponse, currentResponse));
   }
 
   Filter constructFilterFromChildNodesResult(EntityFetcherResponse result) {

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitor.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitor.java
@@ -226,12 +226,7 @@ public class ExecutionVisitor implements Visitor<EntityFetcherResponse> {
                   return entityFetcher.getTimeAggregatedMetrics(requestContext, request);
                 })
             .collect(Collectors.toList()));
-    // Union all the responses from this single source first.
-    EntityFetcherResponse currentResponse =
-        resultMapList.stream().reduce(new EntityFetcherResponse(), (r1, r2) -> union(Arrays.asList(r1, r2)));
-
-    // Intersect the response from this source with the response from the child.
-    return intersect(Arrays.asList(childNodeResponse, currentResponse));
+    return resultMapList.stream().reduce(childNodeResponse, (r1, r2) -> union(Arrays.asList(r1, r2)));
   }
 
   Filter constructFilterFromChildNodesResult(EntityFetcherResponse result) {

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/EntitiesRequestAndResponseUtils.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/EntitiesRequestAndResponseUtils.java
@@ -1,5 +1,6 @@
 package org.hypertrace.gateway.service.common;
 
+import static org.hypertrace.gateway.service.v1.common.Operator.AND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -139,5 +140,20 @@ public class EntitiesRequestAndResponseUtils {
       assertTrue(actualEntityFetcherResponseMap.containsKey(k), "Missing key: " + k);
       assertEquals(expectedEntityFetcherResponseMap.get(k).build(), actualEntityFetcherResponseMap.get(k).build());
     });
+  }
+
+  public static Filter getTimeRangeFilter(String colName, long startTime, long endTime) {
+    return Filter.newBuilder()
+        .setOperator(AND)
+        .addChildFilter(getTimestampFilter(colName, Operator.GE, startTime))
+        .addChildFilter(getTimestampFilter(colName, Operator.LT, endTime))
+        .build();
+  }
+
+  public static Filter getTimestampFilter(String colName, Operator operator, long timestamp) {
+    return Filter.newBuilder()
+        .setOperator(operator)
+        .setLhs(buildExpression(colName))
+        .setRhs(getLiteralExpression(timestamp)).build();
   }
 }

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/QueryServiceRequestAndResponseUtils.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/QueryServiceRequestAndResponseUtils.java
@@ -138,36 +138,19 @@ public class QueryServiceRequestAndResponseUtils {
                                              long endTime,
                                              Filter requestFilter) {
     return Filter.newBuilder()
+        .setOperator(Operator.AND)
         .addChildFilter(
             Filter.newBuilder()
-                .addChildFilter(
-                    createQsFilter(
-                        createQsColumnExpression(timestampColumnName),
-                        Operator.GE,
-                        createQsLongLiteralExpression(startTime)
-                    )
-                )
-                .addChildFilter(
-                    createQsFilter(
-                        createQsColumnExpression(timestampColumnName),
-                        Operator.LT,
-                        createQsLongLiteralExpression(endTime)
-                    )
-                )
+                .setOperator(Operator.AND)
+                .addChildFilter(createQsTimeRangeFilter(timestampColumnName, startTime, endTime))
+                .addChildFilter(requestFilter)
         )
         .addChildFilter(
-            requestFilter
+            createQsFilter(createQsColumnExpression(entityIdColumnName),
+                Operator.NEQ,
+                createQsStringLiteralExpression("null"))
         )
-        .addChildFilter(
-            Filter.newBuilder()
-                .addChildFilter(
-                    createQsFilter(
-                        createQsColumnExpression(entityIdColumnName),
-                        Operator.NEQ,
-                        createQsStringLiteralExpression("null")
-                    )
-                )
-        ).build();
+        .build();
   }
 
   public static Filter createQsDefaultRequestFilter(String timestampColumnName,
@@ -176,28 +159,32 @@ public class QueryServiceRequestAndResponseUtils {
                                                     long endTime) {
     return Filter.newBuilder()
         .setOperator(Operator.AND)
-        .addChildFilter(
-            Filter.newBuilder()
-                .setOperator(Operator.AND)
-                .addChildFilter(
-                    createQsFilter(
-                        createQsColumnExpression(timestampColumnName),
-                        Operator.GE,
-                        createQsLongLiteralExpression(startTime)
-                    )
-                )
-                .addChildFilter(
-                    createQsFilter(
-                        createQsColumnExpression(timestampColumnName),
-                        Operator.LT,
-                        createQsLongLiteralExpression(endTime)
-                    )
-                ))
+        .addChildFilter(createQsTimeRangeFilter(timestampColumnName, startTime, endTime))
         .addChildFilter(
             createQsFilter(
                 createQsColumnExpression(entityIdColumnName),
                 Operator.NEQ,
                 createQsStringLiteralExpression("null")
+            )
+        )
+        .build();
+  }
+
+  private static Filter createQsTimeRangeFilter(String timestampColumnName, long startTime, long endTime) {
+    return Filter.newBuilder()
+        .setOperator(Operator.AND)
+        .addChildFilter(
+            createQsFilter(
+                createQsColumnExpression(timestampColumnName),
+                Operator.GE,
+                createQsLongLiteralExpression(startTime)
+            )
+        )
+        .addChildFilter(
+            createQsFilter(
+                createQsColumnExpression(timestampColumnName),
+                Operator.LT,
+                createQsLongLiteralExpression(endTime)
             )
         )
         .build();

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/QueryServiceRequestAndResponseUtils.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/QueryServiceRequestAndResponseUtils.java
@@ -104,6 +104,19 @@ public class QueryServiceRequestAndResponseUtils {
         .build();
   }
 
+  public static Expression createQsLongLiteralExpression(long val) {
+    return Expression.newBuilder()
+        .setLiteral(
+            LiteralConstant.newBuilder()
+                .setValue(
+                    Value.newBuilder()
+                        .setLong(val)
+                        .setValueType(ValueType.LONG)
+                )
+        )
+        .build();
+  }
+
   public static Filter createQsFilter(Expression lhs, Operator operator, Expression rhs) {
     return Filter.newBuilder()
         .setLhs(lhs)
@@ -131,14 +144,14 @@ public class QueryServiceRequestAndResponseUtils {
                     createQsFilter(
                         createQsColumnExpression(timestampColumnName),
                         Operator.GE,
-                        createQsStringLiteralExpression(Long.toString(startTime))
+                        createQsLongLiteralExpression(startTime)
                     )
                 )
                 .addChildFilter(
                     createQsFilter(
                         createQsColumnExpression(timestampColumnName),
                         Operator.LT,
-                        createQsStringLiteralExpression(Long.toString(endTime))
+                        createQsLongLiteralExpression(endTime)
                     )
                 )
         )
@@ -162,29 +175,31 @@ public class QueryServiceRequestAndResponseUtils {
                                                     long startTime,
                                                     long endTime) {
     return Filter.newBuilder()
-        .addChildFilter(
-            createQsFilter(
-                createQsColumnExpression(timestampColumnName),
-                Operator.GE,
-                createQsStringLiteralExpression(Long.toString(startTime))
-            )
-        )
-        .addChildFilter(
-            createQsFilter(
-                createQsColumnExpression(timestampColumnName),
-                Operator.LT,
-                createQsStringLiteralExpression(Long.toString(endTime))
-            )
-        )
+        .setOperator(Operator.AND)
         .addChildFilter(
             Filter.newBuilder()
+                .setOperator(Operator.AND)
                 .addChildFilter(
                     createQsFilter(
-                        createQsColumnExpression(entityIdColumnName),
-                        Operator.NEQ,
-                        createQsStringLiteralExpression("null")
+                        createQsColumnExpression(timestampColumnName),
+                        Operator.GE,
+                        createQsLongLiteralExpression(startTime)
                     )
                 )
-        ).build();
+                .addChildFilter(
+                    createQsFilter(
+                        createQsColumnExpression(timestampColumnName),
+                        Operator.LT,
+                        createQsLongLiteralExpression(endTime)
+                    )
+                ))
+        .addChildFilter(
+            createQsFilter(
+                createQsColumnExpression(entityIdColumnName),
+                Operator.NEQ,
+                createQsStringLiteralExpression("null")
+            )
+        )
+        .build();
   }
 }

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/converter/GatewayValueToQueryValueConverterTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/converter/GatewayValueToQueryValueConverterTest.java
@@ -53,7 +53,7 @@ public class GatewayValueToQueryValueConverterTest {
     getFilterMap()
         .forEach(
             (gf, qf) ->
-                Assertions.assertEquals(qf, QueryAndGatewayDtoConverter.convertToQueryFilter(gf)));
+                Assertions.assertEquals(qf, QueryAndGatewayDtoConverter.convertToQueryFilter(gf).build()));
   }
 
   private Map<Expression, org.hypertrace.core.query.service.api.Expression>

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
@@ -15,12 +15,15 @@ import static org.hypertrace.gateway.service.common.QueryServiceRequestAndRespon
 import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.createQsRequestFilter;
 import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.createQsStringLiteralExpression;
 import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.getResultSetChunk;
+import static org.hypertrace.gateway.service.v1.common.Operator.AND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.util.List;
@@ -35,10 +38,13 @@ import org.hypertrace.core.query.service.api.ResultSetChunk;
 import org.hypertrace.core.query.service.api.SortOrder;
 import org.hypertrace.core.query.service.client.QueryServiceClient;
 import org.hypertrace.gateway.service.common.AttributeMetadataProvider;
+import org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils;
+import org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils;
 import org.hypertrace.gateway.service.common.RequestContext;
 import org.hypertrace.gateway.service.entity.EntitiesRequestContext;
 import org.hypertrace.gateway.service.entity.EntityKey;
 import org.hypertrace.gateway.service.entity.config.DomainObjectConfigs;
+import org.hypertrace.gateway.service.v1.common.Filter;
 import org.hypertrace.gateway.service.v1.common.FunctionType;
 import org.hypertrace.gateway.service.v1.common.OrderByExpression;
 import org.hypertrace.gateway.service.v1.entity.EntitiesRequest;
@@ -95,7 +101,11 @@ public class QueryServiceEntityFetcherTests {
             .setEndTimeMillis(endTime)
             .addSelection(buildExpression(API_NAME_ATTR))
             .addSelection(buildAggregateExpression(API_DURATION_ATTR, FunctionType.AVG, "AVG_API.duration", List.of()))
-            .setFilter(generateEQFilter(API_DISCOVERY_STATE_ATTR, "DISCOVERED"))
+            .setFilter(
+                Filter.newBuilder().setOperator(AND)
+                .addChildFilter(EntitiesRequestAndResponseUtils.getTimeRangeFilter("API.startTime", startTime, endTime))
+                .addChildFilter(generateEQFilter(API_DISCOVERY_STATE_ATTR, "DISCOVERED"))
+            )
             .addAllOrderBy(orderByExpressions)
             .setLimit(limit)
             .setOffset(offset)
@@ -171,6 +181,11 @@ public class QueryServiceEntityFetcherTests {
     );
     EntityFetcherResponse expectedEntityFetcherResponse = new EntityFetcherResponse(expectedEntityKeyBuilderResponseMap);
 
+    try {
+      System.out.println("Expected: " + JsonFormat.printer().omittingInsignificantWhitespace().print(expectedQueryRequest));
+    } catch (InvalidProtocolBufferException e) {
+      e.printStackTrace();
+    }
     when(queryServiceClient.executeQuery(eq(expectedQueryRequest), eq(requestHeaders), eq(500)))
         .thenReturn(resultSetChunks.iterator());
 
@@ -196,7 +211,11 @@ public class QueryServiceEntityFetcherTests {
             .addSelection(buildExpression(API_NAME_ATTR))
             .addSelection(buildAggregateExpression(API_DURATION_ATTR, FunctionType.AVG, "AVG_API.duration", List.of()))
             .addTimeAggregation(buildTimeAggregation(30, API_NUM_CALLS_ATTR, FunctionType.SUM, "SUM_API.numCalls", List.of()))
-            .setFilter(generateEQFilter(API_DISCOVERY_STATE_ATTR, "DISCOVERED"))
+            .setFilter(
+                Filter.newBuilder().setOperator(AND)
+                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimeRangeFilter("API.startTime", startTime, endTime))
+                    .addChildFilter(generateEQFilter(API_DISCOVERY_STATE_ATTR, "DISCOVERED"))
+            )
             .addAllOrderBy(orderByExpressions)
             .setLimit(limit)
             .setOffset(offset)

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
@@ -1,7 +1,32 @@
 package org.hypertrace.gateway.service.common.datafetcher;
 
+import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildAggregateExpression;
+import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildExpression;
+import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildOrderByExpression;
+import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildTimeAggregation;
+import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.compareEntityFetcherResponses;
+import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.generateEQFilter;
+import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.getAggregatedMetricValue;
+import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.getStringValue;
+import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.createQsAggregationExpression;
+import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.createQsColumnExpression;
+import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.createQsFilter;
+import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.createQsOrderBy;
+import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.createQsRequestFilter;
+import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.createQsStringLiteralExpression;
+import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.getResultSetChunk;
+import static org.hypertrace.gateway.service.v1.common.Operator.AND;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.hypertrace.core.attribute.service.v1.AttributeKind;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
 import org.hypertrace.core.attribute.service.v1.AttributeScope;
@@ -25,32 +50,6 @@ import org.hypertrace.gateway.service.v1.entity.Entity.Builder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildAggregateExpression;
-import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildExpression;
-import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildOrderByExpression;
-import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildTimeAggregation;
-import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.compareEntityFetcherResponses;
-import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.generateEQFilter;
-import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.getAggregatedMetricValue;
-import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.getStringValue;
-import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.createQsAggregationExpression;
-import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.createQsColumnExpression;
-import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.createQsFilter;
-import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.createQsOrderBy;
-import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.createQsRequestFilter;
-import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.createQsStringLiteralExpression;
-import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.getResultSetChunk;
-import static org.hypertrace.gateway.service.v1.common.Operator.AND;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class QueryServiceEntityFetcherTests {
   private static final String API_ID_ATTR = "API.id";

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
@@ -1,5 +1,35 @@
 package org.hypertrace.gateway.service.common.datafetcher;
 
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.hypertrace.core.attribute.service.v1.AttributeKind;
+import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
+import org.hypertrace.core.attribute.service.v1.AttributeScope;
+import org.hypertrace.core.query.service.api.Operator;
+import org.hypertrace.core.query.service.api.QueryRequest;
+import org.hypertrace.core.query.service.api.ResultSetChunk;
+import org.hypertrace.core.query.service.api.SortOrder;
+import org.hypertrace.core.query.service.client.QueryServiceClient;
+import org.hypertrace.gateway.service.common.AttributeMetadataProvider;
+import org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils;
+import org.hypertrace.gateway.service.common.RequestContext;
+import org.hypertrace.gateway.service.entity.EntitiesRequestContext;
+import org.hypertrace.gateway.service.entity.EntityKey;
+import org.hypertrace.gateway.service.entity.config.DomainObjectConfigs;
+import org.hypertrace.gateway.service.v1.common.Filter;
+import org.hypertrace.gateway.service.v1.common.FunctionType;
+import org.hypertrace.gateway.service.v1.common.OrderByExpression;
+import org.hypertrace.gateway.service.v1.entity.EntitiesRequest;
+import org.hypertrace.gateway.service.v1.entity.Entity;
+import org.hypertrace.gateway.service.v1.entity.Entity.Builder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildAggregateExpression;
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildExpression;
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildOrderByExpression;
@@ -21,38 +51,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.util.JsonFormat;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import org.hypertrace.core.attribute.service.v1.AttributeKind;
-import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
-import org.hypertrace.core.attribute.service.v1.AttributeScope;
-import org.hypertrace.core.query.service.api.Operator;
-import org.hypertrace.core.query.service.api.QueryRequest;
-import org.hypertrace.core.query.service.api.ResultSetChunk;
-import org.hypertrace.core.query.service.api.SortOrder;
-import org.hypertrace.core.query.service.client.QueryServiceClient;
-import org.hypertrace.gateway.service.common.AttributeMetadataProvider;
-import org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils;
-import org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils;
-import org.hypertrace.gateway.service.common.RequestContext;
-import org.hypertrace.gateway.service.entity.EntitiesRequestContext;
-import org.hypertrace.gateway.service.entity.EntityKey;
-import org.hypertrace.gateway.service.entity.config.DomainObjectConfigs;
-import org.hypertrace.gateway.service.v1.common.Filter;
-import org.hypertrace.gateway.service.v1.common.FunctionType;
-import org.hypertrace.gateway.service.v1.common.OrderByExpression;
-import org.hypertrace.gateway.service.v1.entity.EntitiesRequest;
-import org.hypertrace.gateway.service.v1.entity.Entity;
-import org.hypertrace.gateway.service.v1.entity.Entity.Builder;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 public class QueryServiceEntityFetcherTests {
   private static final String API_ID_ATTR = "API.id";
@@ -179,13 +177,8 @@ public class QueryServiceEntityFetcherTests {
             .putAttribute(API_ID_ATTR, getStringValue("api-id-3"))
             .putMetric("AVG_API.duration", getAggregatedMetricValue(FunctionType.AVG, 17.0))
     );
-    EntityFetcherResponse expectedEntityFetcherResponse = new EntityFetcherResponse(expectedEntityKeyBuilderResponseMap);
 
-    try {
-      System.out.println("Expected: " + JsonFormat.printer().omittingInsignificantWhitespace().print(expectedQueryRequest));
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
-    }
+    EntityFetcherResponse expectedEntityFetcherResponse = new EntityFetcherResponse(expectedEntityKeyBuilderResponseMap);
     when(queryServiceClient.executeQuery(eq(expectedQueryRequest), eq(requestHeaders), eq(500)))
         .thenReturn(resultSetChunks.iterator());
 

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/transformer/RequestPreProcessorTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/transformer/RequestPreProcessorTest.java
@@ -1,7 +1,14 @@
 package org.hypertrace.gateway.service.common.transformer;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.hypertrace.core.attribute.service.v1.AttributeKind;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
 import org.hypertrace.core.attribute.service.v1.AttributeScope;
@@ -26,14 +33,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-
-import java.io.File;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class RequestPreProcessorTest {
   private static final String TEST_TENANT_ID = "test-tenant-id";
@@ -105,8 +104,8 @@ public class RequestPreProcessorTest {
                             QueryExpressionUtil.getColumnExpression("SERVICE.name"),
                             Operator.LIKE,
                             QueryExpressionUtil.getLiteralExpression("log")))
-                .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, 0L))
-                .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, 1L))
+                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, 0L))
+                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, 1L))
             )
             .addSelection(QueryExpressionUtil.getColumnExpression("SERVICE.id"))
             .addSelection(QueryExpressionUtil.getColumnExpression("SERVICE.name"))

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/EntityServiceTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/EntityServiceTest.java
@@ -195,11 +195,6 @@ public class EntityServiceTest extends AbstractGatewayServiceTest {
         .addGroupBy(createQsColumnExpression("API.apiName", "API Name"))
         .setLimit(QueryServiceClient.DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT)
         .build();
-    try {
-      System.out.println("expected: " + JsonFormat.printer().omittingInsignificantWhitespace().print(expectedQueryRequest));
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
-    }
     when(queryServiceClient.executeQuery(eq(expectedQueryRequest), any(), Mockito.anyInt()))
         .thenReturn(
             List.of(

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/EntityServiceTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/EntityServiceTest.java
@@ -37,8 +37,6 @@ import org.hypertrace.gateway.service.entity.config.DomainObjectConfigs;
 import org.hypertrace.gateway.service.entity.config.LogConfig;
 import org.hypertrace.gateway.service.v1.common.ColumnIdentifier;
 import org.hypertrace.gateway.service.v1.common.Expression;
-import org.hypertrace.gateway.service.v1.common.LiteralConstant;
-import org.hypertrace.gateway.service.v1.common.Operator;
 import org.hypertrace.gateway.service.v1.entity.EntitiesRequest;
 import org.hypertrace.gateway.service.v1.entity.EntitiesResponse;
 import org.hypertrace.gateway.service.v1.entity.Entity;
@@ -251,11 +249,6 @@ public class EntityServiceTest extends AbstractGatewayServiceTest {
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("API")
-            .setFilter(org.hypertrace.gateway.service.v1.common.Filter.newBuilder()
-                .setOperator(Operator.IN)
-                .setLhs(getExpressionFor("API.httpMethod", "API Http method"))
-                .setRhs(getStringListLiteral(List.of("GET", "POST")))
-            )
             .addSelection(getExpressionFor("API.apiId", "API Id"))
             .addSelection(getExpressionFor("API.apiName", "API Name"))
             .addSelection(getExpressionFor("API.httpMethod", "API Http method"))
@@ -263,23 +256,14 @@ public class EntityServiceTest extends AbstractGatewayServiceTest {
     EntitiesResponse response = entityService.getEntities(TENANT_ID, entitiesRequest, Map.of());
     Assertions.assertNotNull(response);
     Assertions.assertEquals(2, response.getTotal());
-    for (Entity entity: response.getEntityList()) {
-      if ("apiId1".equals(entity.getAttributeMap().get("API.apiId").getString())) {
-        Assertions.assertEquals("/login", entity.getAttributeMap().get("API.apiName").getString());
-        Assertions.assertEquals("GET", entity.getAttributeMap().get("API.httpMethod").getString());
-      } else if ("apiId2".equals(entity.getAttributeMap().get("API.apiId").getString())) {
-        Assertions.assertEquals("/checkout", entity.getAttributeMap().get("API.apiName").getString());
-        Assertions.assertEquals("POST", entity.getAttributeMap().get("API.httpMethod").getString());
-      }
-    }
-  }
-
-  private Expression getStringListLiteral(List<String> values) {
-    return Expression.newBuilder().setLiteral(
-        LiteralConstant.newBuilder().setValue(
-            org.hypertrace.gateway.service.v1.common.Value.newBuilder()
-                .setValueType(org.hypertrace.gateway.service.v1.common.ValueType.STRING_ARRAY)
-                .addAllStringArray(values))).build();
+    Entity entity1 = response.getEntity(0);
+    Assertions.assertEquals("apiId1", entity1.getAttributeMap().get("API.apiId").getString());
+    Assertions.assertEquals("/login", entity1.getAttributeMap().get("API.apiName").getString());
+    Assertions.assertEquals("GET", entity1.getAttributeMap().get("API.httpMethod").getString());
+    Entity entity2 = response.getEntity(1);
+    Assertions.assertEquals("apiId2", entity2.getAttributeMap().get("API.apiId").getString());
+    Assertions.assertEquals("/checkout", entity2.getAttributeMap().get("API.apiName").getString());
+    Assertions.assertEquals("POST", entity2.getAttributeMap().get("API.httpMethod").getString());
   }
 
   private Expression getExpressionFor(String columnName, String alias) {

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/EntityServiceTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/EntityServiceTest.java
@@ -37,6 +37,8 @@ import org.hypertrace.gateway.service.entity.config.DomainObjectConfigs;
 import org.hypertrace.gateway.service.entity.config.LogConfig;
 import org.hypertrace.gateway.service.v1.common.ColumnIdentifier;
 import org.hypertrace.gateway.service.v1.common.Expression;
+import org.hypertrace.gateway.service.v1.common.LiteralConstant;
+import org.hypertrace.gateway.service.v1.common.Operator;
 import org.hypertrace.gateway.service.v1.entity.EntitiesRequest;
 import org.hypertrace.gateway.service.v1.entity.EntitiesResponse;
 import org.hypertrace.gateway.service.v1.entity.Entity;
@@ -249,6 +251,11 @@ public class EntityServiceTest extends AbstractGatewayServiceTest {
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("API")
+            .setFilter(org.hypertrace.gateway.service.v1.common.Filter.newBuilder()
+                .setOperator(Operator.IN)
+                .setLhs(getExpressionFor("API.httpMethod", "API Http method"))
+                .setRhs(getStringListLiteral(List.of("GET", "POST")))
+            )
             .addSelection(getExpressionFor("API.apiId", "API Id"))
             .addSelection(getExpressionFor("API.apiName", "API Name"))
             .addSelection(getExpressionFor("API.httpMethod", "API Http method"))
@@ -256,14 +263,23 @@ public class EntityServiceTest extends AbstractGatewayServiceTest {
     EntitiesResponse response = entityService.getEntities(TENANT_ID, entitiesRequest, Map.of());
     Assertions.assertNotNull(response);
     Assertions.assertEquals(2, response.getTotal());
-    Entity entity1 = response.getEntity(0);
-    Assertions.assertEquals("apiId1", entity1.getAttributeMap().get("API.apiId").getString());
-    Assertions.assertEquals("/login", entity1.getAttributeMap().get("API.apiName").getString());
-    Assertions.assertEquals("GET", entity1.getAttributeMap().get("API.httpMethod").getString());
-    Entity entity2 = response.getEntity(1);
-    Assertions.assertEquals("apiId2", entity2.getAttributeMap().get("API.apiId").getString());
-    Assertions.assertEquals("/checkout", entity2.getAttributeMap().get("API.apiName").getString());
-    Assertions.assertEquals("POST", entity2.getAttributeMap().get("API.httpMethod").getString());
+    for (Entity entity: response.getEntityList()) {
+      if ("apiId1".equals(entity.getAttributeMap().get("API.apiId").getString())) {
+        Assertions.assertEquals("/login", entity.getAttributeMap().get("API.apiName").getString());
+        Assertions.assertEquals("GET", entity.getAttributeMap().get("API.httpMethod").getString());
+      } else if ("apiId2".equals(entity.getAttributeMap().get("API.apiId").getString())) {
+        Assertions.assertEquals("/checkout", entity.getAttributeMap().get("API.apiName").getString());
+        Assertions.assertEquals("POST", entity.getAttributeMap().get("API.httpMethod").getString());
+      }
+    }
+  }
+
+  private Expression getStringListLiteral(List<String> values) {
+    return Expression.newBuilder().setLiteral(
+        LiteralConstant.newBuilder().setValue(
+            org.hypertrace.gateway.service.v1.common.Value.newBuilder()
+                .setValueType(org.hypertrace.gateway.service.v1.common.ValueType.STRING_ARRAY)
+                .addAllStringArray(values))).build();
   }
 
   private Expression getExpressionFor(String columnName, String alias) {

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilderTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilderTest.java
@@ -32,7 +32,6 @@ import org.hypertrace.gateway.service.common.RequestContext;
 import org.hypertrace.gateway.service.entity.EntitiesRequestContext;
 import org.hypertrace.gateway.service.entity.config.DomainObjectConfigs;
 import org.hypertrace.gateway.service.entity.query.visitor.OptimizingVisitor;
-import org.hypertrace.gateway.service.entity.query.visitor.PrintVisitor;
 import org.hypertrace.gateway.service.v1.common.Filter;
 import org.hypertrace.gateway.service.v1.common.FunctionType;
 import org.hypertrace.gateway.service.v1.common.Operator;
@@ -738,38 +737,6 @@ public class ExecutionTreeBuilderTest {
         ((SelectionNode) secondChild)
             .getAttrSelectionSources()
             .contains(AttributeSource.EDS.name()));
-  }
-
-  @Test
-  public void test_build_selectAttributeWithFiltersWithDifferentSource_shouldCreateDifferentNode() {
-    EntitiesRequest entitiesRequest =
-        EntitiesRequest.newBuilder()
-            .setEntityType(AttributeScope.API.name())
-            .setFilter(generateEQFilter(API_PATTERN_ATTR, "/login"))
-            .addSelection(buildExpression(API_NAME_ATTR))
-            .addSelection(
-                buildAggregateExpression(API_NUM_CALLS_ATTR,
-                    FunctionType.SUM,
-                    "SUM_numCalls",
-                    List.of()))
-            .build();
-    EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", new HashMap<>());
-    ExecutionContext executionContext =
-        ExecutionContext.from(attributeMetadataProvider, entitiesRequest, entitiesRequestContext);
-    ExecutionTreeBuilder executionTreeBuilder = new ExecutionTreeBuilder(executionContext);
-    QueryNode executionTree = executionTreeBuilder.build();
-    assertNotNull(executionTree);
-    assertTrue(executionTree instanceof SelectionNode);
-    assertTrue(
-        ((SelectionNode) executionTree)
-            .getAggMetricSelectionSources()
-            .contains(AttributeSource.QS.name()));
-    QueryNode firstChild = ((SelectionNode) executionTree).getChildNode();
-    assertTrue(firstChild instanceof SortAndPaginateNode);
-    QueryNode secondChild = ((SortAndPaginateNode) firstChild).getChildNode();
-    assertTrue(secondChild instanceof DataFetcherNode);
-    assertEquals(AttributeSource.EDS.name(), ((DataFetcherNode) secondChild).getSource());
   }
 
   private void mockDomainObjectConfigs() {

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilderTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilderTest.java
@@ -32,6 +32,7 @@ import org.hypertrace.gateway.service.common.RequestContext;
 import org.hypertrace.gateway.service.entity.EntitiesRequestContext;
 import org.hypertrace.gateway.service.entity.config.DomainObjectConfigs;
 import org.hypertrace.gateway.service.entity.query.visitor.OptimizingVisitor;
+import org.hypertrace.gateway.service.entity.query.visitor.PrintVisitor;
 import org.hypertrace.gateway.service.v1.common.Filter;
 import org.hypertrace.gateway.service.v1.common.FunctionType;
 import org.hypertrace.gateway.service.v1.common.Operator;
@@ -737,6 +738,38 @@ public class ExecutionTreeBuilderTest {
         ((SelectionNode) secondChild)
             .getAttrSelectionSources()
             .contains(AttributeSource.EDS.name()));
+  }
+
+  @Test
+  public void test_build_selectAttributeWithFiltersWithDifferentSource_shouldCreateDifferentNode() {
+    EntitiesRequest entitiesRequest =
+        EntitiesRequest.newBuilder()
+            .setEntityType(AttributeScope.API.name())
+            .setFilter(generateEQFilter(API_PATTERN_ATTR, "/login"))
+            .addSelection(buildExpression(API_NAME_ATTR))
+            .addSelection(
+                buildAggregateExpression(API_NUM_CALLS_ATTR,
+                    FunctionType.SUM,
+                    "SUM_numCalls",
+                    List.of()))
+            .build();
+    EntitiesRequestContext entitiesRequestContext =
+        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", new HashMap<>());
+    ExecutionContext executionContext =
+        ExecutionContext.from(attributeMetadataProvider, entitiesRequest, entitiesRequestContext);
+    ExecutionTreeBuilder executionTreeBuilder = new ExecutionTreeBuilder(executionContext);
+    QueryNode executionTree = executionTreeBuilder.build();
+    assertNotNull(executionTree);
+    assertTrue(executionTree instanceof SelectionNode);
+    assertTrue(
+        ((SelectionNode) executionTree)
+            .getAggMetricSelectionSources()
+            .contains(AttributeSource.QS.name()));
+    QueryNode firstChild = ((SelectionNode) executionTree).getChildNode();
+    assertTrue(firstChild instanceof SortAndPaginateNode);
+    QueryNode secondChild = ((SortAndPaginateNode) firstChild).getChildNode();
+    assertTrue(secondChild instanceof DataFetcherNode);
+    assertEquals(AttributeSource.EDS.name(), ((DataFetcherNode) secondChild).getSource());
   }
 
   private void mockDomainObjectConfigs() {

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilderTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilderTest.java
@@ -1,7 +1,32 @@
 package org.hypertrace.gateway.service.entity.query;
 
+import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildAggregateExpression;
+import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildExpression;
+import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildOrderByExpression;
+import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildTimeAggregation;
+import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.generateAndOrNotFilter;
+import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.generateEQFilter;
+import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.generateFilter;
+import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.getTimeRangeFilter;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
 import org.hypertrace.core.attribute.service.v1.AttributeScope;
 import org.hypertrace.core.attribute.service.v1.AttributeSource;
@@ -20,32 +45,6 @@ import org.hypertrace.gateway.service.v1.entity.EntitiesRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildAggregateExpression;
-import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildExpression;
-import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildOrderByExpression;
-import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildTimeAggregation;
-import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.generateAndOrNotFilter;
-import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.generateEQFilter;
-import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.generateFilter;
-import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.getTimeRangeFilter;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class ExecutionTreeBuilderTest {
 

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilderTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilderTest.java
@@ -439,7 +439,6 @@ public class ExecutionTreeBuilderTest {
       ExecutionTreeBuilder executionTreeBuilder = new ExecutionTreeBuilder(executionContext);
       QueryNode executionTree = executionTreeBuilder.build();
       assertNotNull(executionTree);
-      System.out.println(executionTree);
       assertTrue(executionTree instanceof SortAndPaginateNode);
       assertEquals(10, ((SortAndPaginateNode) executionTree).getLimit());
       QueryNode firstChild = ((SortAndPaginateNode) executionTree).getChildNode();
@@ -778,12 +777,8 @@ public class ExecutionTreeBuilderTest {
     ExecutionTreeBuilder executionTreeBuilder = new ExecutionTreeBuilder(executionContext);
     QueryNode executionTree = executionTreeBuilder.build();
     assertNotNull(executionTree);
-    System.out.println(executionTree);
     assertTrue(executionTree instanceof SelectionNode);
-    assertTrue(
-        ((SelectionNode) executionTree)
-            .getAggMetricSelectionSources()
-            .contains(AttributeSource.QS.name()));
+    assertTrue(((SelectionNode) executionTree).getAggMetricSelectionSources().contains(AttributeSource.QS.name()));
     QueryNode firstChild = ((SelectionNode) executionTree).getChildNode();
     assertTrue(firstChild instanceof SortAndPaginateNode);
     QueryNode secondChild = ((SortAndPaginateNode) firstChild).getChildNode();

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitorTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitorTest.java
@@ -10,7 +10,6 @@ import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUt
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.getStringValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -38,7 +37,6 @@ import org.hypertrace.gateway.service.common.datafetcher.QueryServiceEntityFetch
 import org.hypertrace.gateway.service.entity.EntitiesRequestContext;
 import org.hypertrace.gateway.service.entity.EntityKey;
 import org.hypertrace.gateway.service.entity.EntityQueryHandlerRegistry;
-import org.hypertrace.gateway.service.entity.query.DataFetcherNode;
 import org.hypertrace.gateway.service.entity.query.ExecutionContext;
 import org.hypertrace.gateway.service.entity.query.NoOpNode;
 import org.hypertrace.gateway.service.entity.query.PaginateOnlyNode;
@@ -385,34 +383,6 @@ public class ExecutionVisitorTest {
     SelectionAndFilterNode selectionAndFilterNode = new SelectionAndFilterNode("QS", limit, offset);
 
     compareEntityFetcherResponses(entityFetcherResponse, executionVisitor.visit(selectionAndFilterNode));
-  }
-
-  /**
-   * A simple test to verify that the responses are merged properly when multiple data sources are involved in
-   * entities query.
-   */
-  @Test
-  public void testSelectionAndFilterWithMultipleSources() {
-    ExecutionVisitor executionVisitor =
-        spy(new ExecutionVisitor(executionContext, entityQueryHandlerRegistry));
-
-    // Make the first query, which involves a filter to EDS.
-    DataFetcherNode dataFetcherNode = new DataFetcherNode("EDS", generateEQFilter(API_DISCOVERY_STATE, "DISCOVERED"));
-
-    // Let the EDS query return result4, which has one entity in it
-    when(entityDataServiceEntityFetcher.getEntities(any(), any())).thenReturn(result4);
-
-    SelectionNode selectionNode = new SelectionNode.Builder(dataFetcherNode)
-        .setAttrSelectionSources(Set.of(QS_SOURCE))
-        .build();
-    mockExecutionContext(Set.of(QS_SOURCE), Set.of(), Map.of(QS_SOURCE, List.of(buildExpression(API_NAME_ATTR))), Map.of());
-
-    // When the query is made to Query service, don't return any response.
-    when(queryServiceEntityFetcher.getEntities(any(), any())).thenReturn(new EntityFetcherResponse());
-    EntityFetcherResponse response = executionVisitor.visit(selectionNode);
-
-    // The final result should be empty because query service didn't return anything.
-    assertTrue(response.getEntityKeyBuilderMap().isEmpty());
   }
 
   @Test

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitorTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitorTest.java
@@ -10,10 +10,12 @@ import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUt
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.getStringValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -36,6 +38,7 @@ import org.hypertrace.gateway.service.common.datafetcher.QueryServiceEntityFetch
 import org.hypertrace.gateway.service.entity.EntitiesRequestContext;
 import org.hypertrace.gateway.service.entity.EntityKey;
 import org.hypertrace.gateway.service.entity.EntityQueryHandlerRegistry;
+import org.hypertrace.gateway.service.entity.query.DataFetcherNode;
 import org.hypertrace.gateway.service.entity.query.ExecutionContext;
 import org.hypertrace.gateway.service.entity.query.NoOpNode;
 import org.hypertrace.gateway.service.entity.query.PaginateOnlyNode;
@@ -43,6 +46,7 @@ import org.hypertrace.gateway.service.entity.query.SelectionAndFilterNode;
 import org.hypertrace.gateway.service.entity.query.SelectionNode;
 import org.hypertrace.gateway.service.entity.query.TotalFetcherNode;
 import org.hypertrace.gateway.service.v1.common.ColumnIdentifier;
+import org.hypertrace.gateway.service.v1.common.DomainEntityType;
 import org.hypertrace.gateway.service.v1.common.Expression;
 import org.hypertrace.gateway.service.v1.common.Filter;
 import org.hypertrace.gateway.service.v1.common.FunctionType;
@@ -74,7 +78,7 @@ public class ExecutionVisitorTest {
   private static final String API_DURATION_ATTR = "API.duration";
   private static final String API_DISCOVERY_STATE = "API.apiDiscoveryState";
 
-  private EntityFetcherResponse result1 =
+  private final EntityFetcherResponse result1 =
       new EntityFetcherResponse(
           Map.of(
               EntityKey.of("id1"),
@@ -83,21 +87,21 @@ public class ExecutionVisitorTest {
                   Entity.newBuilder().putAttribute("key12", getStringValue("value12")),
               EntityKey.of("id3"),
                   Entity.newBuilder().putAttribute("key13", getStringValue("value13"))));
-  private EntityFetcherResponse result2 =
+  private final EntityFetcherResponse result2 =
       new EntityFetcherResponse(
           Map.of(
               EntityKey.of("id1"),
                   Entity.newBuilder().putAttribute("key21", getStringValue("value21")),
               EntityKey.of("id2"),
                   Entity.newBuilder().putAttribute("key22", getStringValue("value22"))));
-  private EntityFetcherResponse result3 =
+  private final EntityFetcherResponse result3 =
       new EntityFetcherResponse(
           Map.of(
               EntityKey.of("id1"),
                   Entity.newBuilder().putAttribute("key31", getStringValue("value31")),
               EntityKey.of("id3"),
                   Entity.newBuilder().putAttribute("key33", getStringValue("value33"))));
-  private EntityFetcherResponse result4 =
+  private final EntityFetcherResponse result4 =
       new EntityFetcherResponse(
           Map.of(
               EntityKey.of("id4"),
@@ -381,6 +385,34 @@ public class ExecutionVisitorTest {
     SelectionAndFilterNode selectionAndFilterNode = new SelectionAndFilterNode("QS", limit, offset);
 
     compareEntityFetcherResponses(entityFetcherResponse, executionVisitor.visit(selectionAndFilterNode));
+  }
+
+  /**
+   * A simple test to verify that the responses are merged properly when multiple data sources are involved in
+   * entities query.
+   */
+  @Test
+  public void testSelectionAndFilterWithMultipleSources() {
+    ExecutionVisitor executionVisitor =
+        spy(new ExecutionVisitor(executionContext, entityQueryHandlerRegistry));
+
+    // Make the first query, which involves a filter to EDS.
+    DataFetcherNode dataFetcherNode = new DataFetcherNode("EDS", generateEQFilter(API_DISCOVERY_STATE, "DISCOVERED"));
+
+    // Let the EDS query return result4, which has one entity in it
+    when(entityDataServiceEntityFetcher.getEntities(any(), any())).thenReturn(result4);
+
+    SelectionNode selectionNode = new SelectionNode.Builder(dataFetcherNode)
+        .setAttrSelectionSources(Set.of(QS_SOURCE))
+        .build();
+    mockExecutionContext(Set.of(QS_SOURCE), Set.of(), Map.of(QS_SOURCE, List.of(buildExpression(API_NAME_ATTR))), Map.of());
+
+    // When the query is made to Query service, don't return any response.
+    when(queryServiceEntityFetcher.getEntities(any(), any())).thenReturn(new EntityFetcherResponse());
+    EntityFetcherResponse response = executionVisitor.visit(selectionNode);
+
+    // The final result should be empty because query service didn't return anything.
+    assertTrue(response.getEntityKeyBuilderMap().isEmpty());
   }
 
   @Test
@@ -697,6 +729,33 @@ public class ExecutionVisitorTest {
     executionVisitor.visit(selectionNode);
     verify(entityDataServiceEntityFetcher).getEntities(any(), any());
     verify(queryServiceEntityFetcher).getAggregatedMetrics(any(), any());
+  }
+
+  @Test
+  public void test_visitSelectionNode_nonEmptyFilter_emptyResult() {
+    // Create a request with non-empty filter.
+    EntitiesRequest entitiesRequest =
+        EntitiesRequest.newBuilder()
+            .setEntityType(DomainEntityType.API.name())
+            .setStartTimeMillis(10)
+            .setEndTimeMillis(20)
+            .addSelection(buildExpression(API_NAME_ATTR))
+            .setFilter(generateEQFilter(API_DISCOVERY_STATE, "DISCOVERED"))
+            .build();
+    ExecutionVisitor executionVisitor =
+        spy(new ExecutionVisitor(executionContext, entityQueryHandlerRegistry));
+    when(executionContext.getEntitiesRequest()).thenReturn(entitiesRequest);
+
+    // Selection node with NoOp child, to short-circuit the call to first service.
+    SelectionNode selectionNode = new SelectionNode.Builder(new NoOpNode())
+        .setAttrSelectionSources(Set.of(EDS_SOURCE))
+        .setAggMetricSelectionSources(Set.of(QS_SOURCE))
+        .build();
+
+    EntityFetcherResponse response = executionVisitor.visit(selectionNode);
+    Assertions.assertTrue(response.isEmpty());
+    verify(queryServiceEntityFetcher, never()).getEntities(any(), any());
+    verify(queryServiceEntityFetcher, never()).getAggregatedMetrics(any(), any());
   }
 
   private MetricSeries getMockMetricSeries(int period, String aggregation) {

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitorTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitorTest.java
@@ -10,12 +10,10 @@ import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUt
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.getStringValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -38,7 +36,6 @@ import org.hypertrace.gateway.service.common.datafetcher.QueryServiceEntityFetch
 import org.hypertrace.gateway.service.entity.EntitiesRequestContext;
 import org.hypertrace.gateway.service.entity.EntityKey;
 import org.hypertrace.gateway.service.entity.EntityQueryHandlerRegistry;
-import org.hypertrace.gateway.service.entity.query.DataFetcherNode;
 import org.hypertrace.gateway.service.entity.query.ExecutionContext;
 import org.hypertrace.gateway.service.entity.query.NoOpNode;
 import org.hypertrace.gateway.service.entity.query.PaginateOnlyNode;
@@ -46,7 +43,6 @@ import org.hypertrace.gateway.service.entity.query.SelectionAndFilterNode;
 import org.hypertrace.gateway.service.entity.query.SelectionNode;
 import org.hypertrace.gateway.service.entity.query.TotalFetcherNode;
 import org.hypertrace.gateway.service.v1.common.ColumnIdentifier;
-import org.hypertrace.gateway.service.v1.common.DomainEntityType;
 import org.hypertrace.gateway.service.v1.common.Expression;
 import org.hypertrace.gateway.service.v1.common.Filter;
 import org.hypertrace.gateway.service.v1.common.FunctionType;
@@ -78,7 +74,7 @@ public class ExecutionVisitorTest {
   private static final String API_DURATION_ATTR = "API.duration";
   private static final String API_DISCOVERY_STATE = "API.apiDiscoveryState";
 
-  private final EntityFetcherResponse result1 =
+  private EntityFetcherResponse result1 =
       new EntityFetcherResponse(
           Map.of(
               EntityKey.of("id1"),
@@ -87,21 +83,21 @@ public class ExecutionVisitorTest {
                   Entity.newBuilder().putAttribute("key12", getStringValue("value12")),
               EntityKey.of("id3"),
                   Entity.newBuilder().putAttribute("key13", getStringValue("value13"))));
-  private final EntityFetcherResponse result2 =
+  private EntityFetcherResponse result2 =
       new EntityFetcherResponse(
           Map.of(
               EntityKey.of("id1"),
                   Entity.newBuilder().putAttribute("key21", getStringValue("value21")),
               EntityKey.of("id2"),
                   Entity.newBuilder().putAttribute("key22", getStringValue("value22"))));
-  private final EntityFetcherResponse result3 =
+  private EntityFetcherResponse result3 =
       new EntityFetcherResponse(
           Map.of(
               EntityKey.of("id1"),
                   Entity.newBuilder().putAttribute("key31", getStringValue("value31")),
               EntityKey.of("id3"),
                   Entity.newBuilder().putAttribute("key33", getStringValue("value33"))));
-  private final EntityFetcherResponse result4 =
+  private EntityFetcherResponse result4 =
       new EntityFetcherResponse(
           Map.of(
               EntityKey.of("id4"),
@@ -385,34 +381,6 @@ public class ExecutionVisitorTest {
     SelectionAndFilterNode selectionAndFilterNode = new SelectionAndFilterNode("QS", limit, offset);
 
     compareEntityFetcherResponses(entityFetcherResponse, executionVisitor.visit(selectionAndFilterNode));
-  }
-
-  /**
-   * A simple test to verify that the responses are merged properly when multiple data sources are involved in
-   * entities query.
-   */
-  @Test
-  public void testSelectionAndFilterWithMultipleSources() {
-    ExecutionVisitor executionVisitor =
-        spy(new ExecutionVisitor(executionContext, entityQueryHandlerRegistry));
-
-    // Make the first query, which involves a filter to EDS.
-    DataFetcherNode dataFetcherNode = new DataFetcherNode("EDS", generateEQFilter(API_DISCOVERY_STATE, "DISCOVERED"));
-
-    // Let the EDS query return result4, which has one entity in it
-    when(entityDataServiceEntityFetcher.getEntities(any(), any())).thenReturn(result4);
-
-    SelectionNode selectionNode = new SelectionNode.Builder(dataFetcherNode)
-        .setAttrSelectionSources(Set.of(QS_SOURCE))
-        .build();
-    mockExecutionContext(Set.of(QS_SOURCE), Set.of(), Map.of(QS_SOURCE, List.of(buildExpression(API_NAME_ATTR))), Map.of());
-
-    // When the query is made to Query service, don't return any response.
-    when(queryServiceEntityFetcher.getEntities(any(), any())).thenReturn(new EntityFetcherResponse());
-    EntityFetcherResponse response = executionVisitor.visit(selectionNode);
-
-    // The final result should be empty because query service didn't return anything.
-    assertTrue(response.getEntityKeyBuilderMap().isEmpty());
   }
 
   @Test
@@ -729,33 +697,6 @@ public class ExecutionVisitorTest {
     executionVisitor.visit(selectionNode);
     verify(entityDataServiceEntityFetcher).getEntities(any(), any());
     verify(queryServiceEntityFetcher).getAggregatedMetrics(any(), any());
-  }
-
-  @Test
-  public void test_visitSelectionNode_nonEmptyFilter_emptyResult() {
-    // Create a request with non-empty filter.
-    EntitiesRequest entitiesRequest =
-        EntitiesRequest.newBuilder()
-            .setEntityType(DomainEntityType.API.name())
-            .setStartTimeMillis(10)
-            .setEndTimeMillis(20)
-            .addSelection(buildExpression(API_NAME_ATTR))
-            .setFilter(generateEQFilter(API_DISCOVERY_STATE, "DISCOVERED"))
-            .build();
-    ExecutionVisitor executionVisitor =
-        spy(new ExecutionVisitor(executionContext, entityQueryHandlerRegistry));
-    when(executionContext.getEntitiesRequest()).thenReturn(entitiesRequest);
-
-    // Selection node with NoOp child, to short-circuit the call to first service.
-    SelectionNode selectionNode = new SelectionNode.Builder(new NoOpNode())
-        .setAttrSelectionSources(Set.of(EDS_SOURCE))
-        .setAggMetricSelectionSources(Set.of(QS_SOURCE))
-        .build();
-
-    EntityFetcherResponse response = executionVisitor.visit(selectionNode);
-    Assertions.assertTrue(response.isEmpty());
-    verify(queryServiceEntityFetcher, never()).getEntities(any(), any());
-    verify(queryServiceEntityFetcher, never()).getAggregatedMetrics(any(), any());
   }
 
   private MetricSeries getMockMetricSeries(int period, String aggregation) {

--- a/gateway-service-impl/src/test/resources/configs/request-preprocessor-test/domains-config.conf
+++ b/gateway-service-impl/src/test/resources/configs/request-preprocessor-test/domains-config.conf
@@ -28,6 +28,16 @@ domainobject.config = [
     ]
   },
   {
+      scope = EVENT
+      key = startTime
+      mapping = [
+        {
+          scope = SERVICE
+          key = startTime
+        }
+      ]
+    },
+  {
     scope = EVENT
     key = duration
     mapping = [


### PR DESCRIPTION
**Why this PR?**
This PR is fixing a bug in entity queries, which causes the query layer to error out when a query is asking for entity attributes that span across the EDS and QueryService data sources, in the case there is no data for that entity in QueryService.

**What's the fix?**
Currently, the query federation code that we have (see https://github.com/hypertrace/gateway-service/tree/main/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query) doesn't treat the timestamp predicates in the query like other regular predicates. The timestamps are special cased and they're added to the upstream requests only when the query is being sent to a remote service. That's what caused the above mentioned bug.

This PR treats the timestamp predicates, just like any other predicates in the filter. However, the timestamps are first-class fields in the API and we don't want to remove them because they're mandatory in each entity query (at least in the current design). Hence, the timestamp filter is added to the query request in the request pre-processor so that all the query execution tree shouldn't special case timestamp. Code simplified in those layers and even the implementations of `IEntityFetcher` interface.

There is another existing tech debt (https://github.com/hypertrace/hypertrace/issues/119), which this PR isn't addressing yet. We current use the object received on the API (the proto class `EntitiesRequest`) throughout in the implementation code but we shouldn't. That will be a nice tech debt to cleanup when we get time.