### PR TITLE
fix: Pushing down the mandatory time range check from entities request to QueryServiceEntityFetcher.

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/GatewayServiceImpl.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/GatewayServiceImpl.java
@@ -169,12 +169,6 @@ public class GatewayServiceImpl extends GatewayServiceGrpc.GatewayServiceImplBas
       Preconditions.checkArgument(
           request.getSelectionCount() > 0, "Selection list can't be empty in the request.");
 
-      Preconditions.checkArgument(
-          request.getStartTimeMillis() > 0
-              && request.getEndTimeMillis() > 0
-              && request.getStartTimeMillis() < request.getEndTimeMillis(),
-          "Invalid time range. Both start and end times have to be valid timestamps.");
-
       EntitiesResponse response =
           entityService.getEntities(
               tenantId.get(),

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcher.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcher.java
@@ -75,9 +75,24 @@ public class QueryServiceEntityFetcher implements IEntityFetcher {
     this.attributeMetadataProvider = attributeMetadataProvider;
   }
 
+  /**
+   * Since query service has time series data, time range is must for all query service requests.
+   * This method validates that the received time range is valid in the EntitiesRequest.
+   */
+  private void validateTimeRange(EntitiesRequest request) {
+    Preconditions.checkArgument(
+        request.getStartTimeMillis() > 0
+            && request.getEndTimeMillis() > 0
+            && request.getStartTimeMillis() < request.getEndTimeMillis(),
+        "Invalid time range. Both start and end times have to be valid timestamps.");
+  }
+
   @Override
   public EntityFetcherResponse getEntities(
       EntitiesRequestContext requestContext, EntitiesRequest entitiesRequest) {
+    // Time range is mandatory.
+    validateTimeRange(entitiesRequest);
+
     Map<String, AttributeMetadata> attributeMetadataMap =
         attributeMetadataProvider.getAttributesMetadata(
             requestContext, entitiesRequest.getEntityType());
@@ -160,6 +175,9 @@ public class QueryServiceEntityFetcher implements IEntityFetcher {
   @Override
   public EntityFetcherResponse getAggregatedMetrics(
       EntitiesRequestContext requestContext, EntitiesRequest entitiesRequest) {
+    // Time range is mandatory.
+    validateTimeRange(entitiesRequest);
+
     // Only supported filter is entityIds IN ["id1", "id2", "id3"]
     Map<String, AttributeMetadata> attributeMetadataMap =
         attributeMetadataProvider.getAttributesMetadata(
@@ -251,6 +269,9 @@ public class QueryServiceEntityFetcher implements IEntityFetcher {
   @Override
   public EntityFetcherResponse getEntitiesAndAggregatedMetrics(
       EntitiesRequestContext requestContext, EntitiesRequest entitiesRequest) {
+    // Time range is mandatory.
+    validateTimeRange(entitiesRequest);
+
     // Validate EntitiesRequest
     Map<String, AttributeMetadata> attributeMetadataMap =
         attributeMetadataProvider.getAttributesMetadata(
@@ -489,6 +510,9 @@ public class QueryServiceEntityFetcher implements IEntityFetcher {
   @Override
   public EntityFetcherResponse getTimeAggregatedMetrics(
       EntitiesRequestContext requestContext, EntitiesRequest entitiesRequest) {
+    // Time range is mandatory.
+    validateTimeRange(entitiesRequest);
+
     // No need to make execute the rest of this if there are no TimeAggregations in the request.
     if (entitiesRequest.getTimeAggregationCount() == 0) {
       return new EntityFetcherResponse();
@@ -649,6 +673,9 @@ public class QueryServiceEntityFetcher implements IEntityFetcher {
 
   @Override
   public int getTotalEntities(EntitiesRequestContext requestContext, EntitiesRequest entitiesRequest) {
+    // Time range is mandatory.
+    validateTimeRange(entitiesRequest);
+
     Map<String, AttributeMetadata> attributeMetadataMap =
         attributeMetadataProvider.getAttributesMetadata(
             requestContext, entitiesRequest.getEntityType());

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
@@ -84,7 +84,7 @@ public class QueryServiceEntityFetcherTests {
   @Test
   public void test_getEntitiesAndAggregatedMetrics() {
     List<OrderByExpression> orderByExpressions = List.of(buildOrderByExpression(API_ID_ATTR));
-    long startTime = 0L;
+    long startTime = 1L;
     long endTime = 10L;
     int limit = 10;
     int offset = 0;
@@ -188,7 +188,7 @@ public class QueryServiceEntityFetcherTests {
   @Test
   public void test_getTotalEntitiesSingleEntityIdAttribute() {
     List<OrderByExpression> orderByExpressions = List.of(buildOrderByExpression(API_ID_ATTR));
-    long startTime = 0L;
+    long startTime = 1L;
     long endTime = 10L;
     int limit = 10;
     int offset = 0;

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/transformer/RequestPreProcessorTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/transformer/RequestPreProcessorTest.java
@@ -56,16 +56,18 @@ public class RequestPreProcessorTest {
   @Test
   public void testServiceEntitiesRequestDuplicateColumnSelectionIsRemoved() {
     initializeDomainObjectConfigs("configs/request-preprocessor-test/service-id-config.conf");
+    long endTime = System.currentTimeMillis();
+    long startTime = endTime - 1000L;
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TEST_TENANT_ID, 0L, 1L, "SERVICE", Map.of());
+        new EntitiesRequestContext(TEST_TENANT_ID, startTime, endTime, "SERVICE", Map.of());
     mockAttributeMetadata(entitiesRequestContext, AttributeScope.SERVICE.name(), "id");
     mockAttributeMetadata(entitiesRequestContext, AttributeScope.SERVICE.name(), "startTime");
 
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("SERVICE")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 GatewayExpressionCreator.createFilter(
                     QueryExpressionUtil.getColumnExpression("SERVICE.name"),
@@ -94,8 +96,8 @@ public class RequestPreProcessorTest {
     Assertions.assertEquals(
         EntitiesRequest.newBuilder()
             .setEntityType("SERVICE")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 Filter.newBuilder()
                     .setOperator(Operator.AND)
@@ -104,8 +106,8 @@ public class RequestPreProcessorTest {
                             QueryExpressionUtil.getColumnExpression("SERVICE.name"),
                             Operator.LIKE,
                             QueryExpressionUtil.getLiteralExpression("log")))
-                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, 0L))
-                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, 1L))
+                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, startTime))
+                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, endTime))
             )
             .addSelection(QueryExpressionUtil.getColumnExpression("SERVICE.id"))
             .addSelection(QueryExpressionUtil.getColumnExpression("SERVICE.name"))
@@ -125,16 +127,18 @@ public class RequestPreProcessorTest {
   @Test
   public void testDomainEntitiesRequestWithLikeFilterIsTransformed() {
     initializeDomainObjectConfigs("configs/request-preprocessor-test/domains-config.conf");
+    long endTime = System.currentTimeMillis();
+    long startTime = endTime - 1000L;
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TEST_TENANT_ID, 0L, 1L, "EVENT", Map.of());
+        new EntitiesRequestContext(TEST_TENANT_ID, startTime, endTime, "EVENT", Map.of());
     // Mock calls into attributeMetadataProvider
     mockAttributeMetadataForDomainAndMappings(entitiesRequestContext);
 
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("EVENT")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 GatewayExpressionCreator.createFilter(
                     QueryExpressionUtil.getColumnExpression("EVENT.name"),
@@ -163,8 +167,8 @@ public class RequestPreProcessorTest {
     Assertions.assertEquals(
         EntitiesRequest.newBuilder()
             .setEntityType("EVENT")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 Filter.newBuilder()
                     .setOperator(Operator.AND)
@@ -180,8 +184,8 @@ public class RequestPreProcessorTest {
                                 QueryExpressionUtil.getColumnExpression("SERVICE.hostHeader"),
                                 Operator.LIKE,
                                 QueryExpressionUtil.getLiteralExpression("log")))
-                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, 0L))
-                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, 1L))
+                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, startTime))
+                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, endTime))
                     )
             )
             .addSelection(QueryExpressionUtil.getColumnExpression("SERVICE.hostHeader"))
@@ -203,16 +207,18 @@ public class RequestPreProcessorTest {
   @Test
   public void testDomainEntitiesRequestWithNeqFilterIsTransformed() {
     initializeDomainObjectConfigs("configs/request-preprocessor-test/domains-config.conf");
+    long endTime = System.currentTimeMillis();
+    long startTime = endTime - 1000L;
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TEST_TENANT_ID, 0L, 1L, "EVENT", Map.of());
+        new EntitiesRequestContext(TEST_TENANT_ID, startTime, endTime, "EVENT", Map.of());
     // Mock calls into attributeMetadataProvider
     mockAttributeMetadataForDomainAndMappings(entitiesRequestContext);
 
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("EVENT")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 GatewayExpressionCreator.createFilter(
                     QueryExpressionUtil.getColumnExpression("EVENT.name"),
@@ -235,8 +241,8 @@ public class RequestPreProcessorTest {
     EntitiesRequest expectedRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("EVENT")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 Filter.newBuilder()
                     .setOperator(Operator.AND)
@@ -255,8 +261,8 @@ public class RequestPreProcessorTest {
                                 Operator.NEQ,
                                 QueryExpressionUtil.getLiteralExpression(
                                     "some-entity-name")))
-                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, 0L))
-                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, 1L))
+                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, startTime))
+                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, endTime))
                     )
             )
             .addSelection(QueryExpressionUtil.getColumnExpression("SERVICE.hostHeader"))
@@ -275,16 +281,18 @@ public class RequestPreProcessorTest {
   @Test
   public void testDomainEntitiesRequestWithServiceIdFilterIsNotTransformed() {
     initializeDomainObjectConfigs("configs/request-preprocessor-test/domains-config.conf");
+    long endTime = System.currentTimeMillis();
+    long startTime = endTime - 1000L;
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TEST_TENANT_ID, 0L, 1L, "SERVICE", Map.of());
+        new EntitiesRequestContext(TEST_TENANT_ID, startTime, endTime, "SERVICE", Map.of());
     // Mock calls into attributeMetadataProvider
     mockAttributeMetadataForDomainAndMappings(entitiesRequestContext);
 
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("SERVICE")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 GatewayExpressionCreator.createFilter(
                     QueryExpressionUtil.getColumnExpression("SERVICE.id"),
@@ -299,8 +307,8 @@ public class RequestPreProcessorTest {
     EntitiesRequest expectedRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("SERVICE")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 Filter.newBuilder()
                     .setOperator(Operator.AND)
@@ -311,8 +319,8 @@ public class RequestPreProcessorTest {
                             createStringArrayLiteralExpressionBuilder(List.of("service1-id", "service2-id"))
                         )
                     )
-                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, 0L))
-                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, 1L))
+                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, startTime))
+                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, endTime))
             )
             .addSelection(QueryExpressionUtil.getColumnExpression("SERVICE.id"))
             .build();
@@ -326,16 +334,18 @@ public class RequestPreProcessorTest {
   @Test
   public void testDomainEntitiesRequestWithInFilterIsTransformed() {
     initializeDomainObjectConfigs("configs/request-preprocessor-test/domains-config.conf");
+    long endTime = System.currentTimeMillis();
+    long startTime = endTime - 1000L;
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TEST_TENANT_ID, 0L, 1L, "EVENT", Map.of());
+        new EntitiesRequestContext(TEST_TENANT_ID, startTime, endTime, "EVENT", Map.of());
     // Mock calls into attributeMetadataProvider
     mockAttributeMetadataForDomainAndMappings(entitiesRequestContext);
 
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("SERVICE")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 GatewayExpressionCreator.createFilter(
                     QueryExpressionUtil.getColumnExpression("SERVICE.mappedAttr1"),
@@ -352,8 +362,8 @@ public class RequestPreProcessorTest {
     Assertions.assertEquals(
         EntitiesRequest.newBuilder()
             .setEntityType("SERVICE")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 Filter.newBuilder()
                     .setOperator(Operator.AND)
@@ -401,8 +411,8 @@ public class RequestPreProcessorTest {
                                     )
                             )
                     )
-                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, 0L))
-                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, 1L))
+                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, startTime))
+                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, endTime))
             )
             .addSelection(QueryExpressionUtil.getColumnExpression("SERVICE.attr1"))
             .addSelection(QueryExpressionUtil.getColumnExpression("SERVICE.attr2"))
@@ -414,16 +424,18 @@ public class RequestPreProcessorTest {
   @Test
   public void testDomainEntitiesRequestWithEqFilterIsTransformed() {
     initializeDomainObjectConfigs("configs/request-preprocessor-test/domains-config.conf");
+    long endTime = System.currentTimeMillis();
+    long startTime = endTime - 1000L;
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TEST_TENANT_ID, 0L, 1L, "EVENT", Map.of());
+        new EntitiesRequestContext(TEST_TENANT_ID, startTime, endTime, "EVENT", Map.of());
     // Mock calls into attributeMetadataProvider
     mockAttributeMetadataForDomainAndMappings(entitiesRequestContext);
 
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("SERVICE")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 GatewayExpressionCreator.createFilter(
                     QueryExpressionUtil.getColumnExpression("SERVICE.mappedAttr2"),
@@ -442,8 +454,8 @@ public class RequestPreProcessorTest {
     Assertions.assertEquals(
         EntitiesRequest.newBuilder()
             .setEntityType("SERVICE")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 Filter.newBuilder()
                     .setOperator(Operator.AND)
@@ -464,8 +476,8 @@ public class RequestPreProcessorTest {
                                     GatewayExpressionCreator.createLiteralExpression("attr10_val20")
                                 )
                             )
-                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, 0L))
-                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, 1L))
+                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, startTime))
+                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, endTime))
                     )
             )
             .addSelection(QueryExpressionUtil.getColumnExpression("SERVICE.mappedAttr2"))


### PR DESCRIPTION
## Description
Pushing down the mandatory time range check from entities request to QueryServiceEntityFetcher, because time range is mandatory only for query service.

This allows the entity queries which only require data from EDS to work without any
time range.

### Testing
Apart from the unit tests, tested with locally built image in real setup.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
The start_time_millis and end_time_millis in the `EntitiesRequest` aren't mandatory anymore with this change,
unless you are either requesting attributes that are changing with time or asking for metrics. As an example, all you
need is api name, id and http methods then the query can hit EDS and no need of time range.