### PR TITLE
fix: Fixing a bug in query execution, which wasn't passing the time range in filter to query service.

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,8 +2,9 @@
 version: v1.14.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  SNYK-JAVA-IOGRPC-571957:
+  SNYK-JAVA-IONETTY-1042268:
     - '*':
         reason: No replacement available
-        expires: 2020-08-31T00:00:00.000Z
+        expires: 2021-01-31T00:00:00.000Z
+
 patch: {}

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcher.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcher.java
@@ -4,8 +4,6 @@ import static org.hypertrace.gateway.service.common.converters.QueryAndGatewayDt
 import static org.hypertrace.gateway.service.common.converters.QueryAndGatewayDtoConverter.convertToQueryFilter;
 
 import com.google.common.base.Preconditions;
-import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.util.JsonFormat;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
@@ -279,11 +277,6 @@ public class QueryServiceEntityFetcher implements IEntityFetcher {
       LOG.debug("Sending Query to Query Service ======== \n {}", queryRequest);
     }
 
-    try {
-      System.out.println("Actual: " + JsonFormat.printer().omittingInsignificantWhitespace().print(queryRequest));
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
-    }
     Iterator<ResultSetChunk> resultSetChunkIterator =
         queryServiceClient.executeQuery(queryRequest, requestContext.getHeaders(), requestTimeout);
 

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/util/TimeRangeFilterUtil.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/util/TimeRangeFilterUtil.java
@@ -1,0 +1,31 @@
+package org.hypertrace.gateway.service.common.util;
+
+import static org.hypertrace.gateway.service.v1.common.Operator.AND;
+
+import org.hypertrace.gateway.service.v1.common.ColumnIdentifier;
+import org.hypertrace.gateway.service.v1.common.Expression;
+import org.hypertrace.gateway.service.v1.common.Filter;
+import org.hypertrace.gateway.service.v1.common.LiteralConstant;
+import org.hypertrace.gateway.service.v1.common.Operator;
+import org.hypertrace.gateway.service.v1.common.Value;
+import org.hypertrace.gateway.service.v1.common.ValueType;
+
+public class TimeRangeFilterUtil {
+  public static Filter addTimeRangeFilter(String timestampAttribute, Filter filter, long startTime, long endTime) {
+    Filter.Builder filterBuilder = Filter.newBuilder().setOperator(AND);
+    if (!Filter.getDefaultInstance().equals(filter)) {
+      filterBuilder.addChildFilter(filter);
+    }
+    filterBuilder.addChildFilter(getTimestampFilter(timestampAttribute, Operator.GE, startTime))
+        .addChildFilter(getTimestampFilter(timestampAttribute, Operator.LT, endTime));
+    return filterBuilder.build();
+  }
+
+  private static Filter getTimestampFilter(String colName, Operator operator, long timestamp) {
+    return Filter.newBuilder().setOperator(operator)
+        .setLhs(Expression.newBuilder().setColumnIdentifier(ColumnIdentifier.newBuilder().setColumnName(colName)))
+        .setRhs(Expression.newBuilder().setLiteral(
+            LiteralConstant.newBuilder().setValue(Value.newBuilder().setValueType(ValueType.LONG).setLong(timestamp))))
+        .build();
+  }
+}

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/EntitiesRequestContext.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/EntitiesRequestContext.java
@@ -6,19 +6,26 @@ import org.hypertrace.gateway.service.common.QueryRequestContext;
 
 public class EntitiesRequestContext extends QueryRequestContext {
   private final String entityType;
+  private final String timestampAttributeId;
 
   public EntitiesRequestContext(
       String tenantId,
       long startTimeMillis,
       long endTimeMillis,
       String entityType,
+      String timestampAttributeId,
       Map<String, String> requestHeaders) {
     super(tenantId, startTimeMillis, endTimeMillis, requestHeaders);
     this.entityType = entityType;
+    this.timestampAttributeId = timestampAttributeId;
   }
 
   public String getEntityType() {
     return this.entityType;
+  }
+
+  public String getTimestampAttributeId() {
+    return timestampAttributeId;
   }
 
   @Override
@@ -27,11 +34,12 @@ public class EntitiesRequestContext extends QueryRequestContext {
     if (o == null || getClass() != o.getClass()) return false;
     if (!super.equals(o)) return false;
     EntitiesRequestContext that = (EntitiesRequestContext) o;
-    return Objects.equals(entityType, that.entityType);
+    return entityType.equals(that.entityType) &&
+        timestampAttributeId.equals(that.timestampAttributeId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), entityType);
+    return Objects.hash(super.hashCode(), entityType, timestampAttributeId);
   }
 }

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/EntityService.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/EntityService.java
@@ -22,6 +22,7 @@ import org.hypertrace.gateway.service.common.datafetcher.EntityInteractionsFetch
 import org.hypertrace.gateway.service.common.datafetcher.QueryServiceEntityFetcher;
 import org.hypertrace.gateway.service.common.transformer.RequestPreProcessor;
 import org.hypertrace.gateway.service.common.transformer.ResponsePostProcessor;
+import org.hypertrace.gateway.service.common.util.AttributeMetadataUtil;
 import org.hypertrace.gateway.service.entity.config.LogConfig;
 import org.hypertrace.gateway.service.entity.query.ExecutionContext;
 import org.hypertrace.gateway.service.entity.query.ExecutionTreeBuilder;
@@ -107,6 +108,9 @@ public class EntityService {
   public EntitiesResponse getEntities(
       String tenantId, EntitiesRequest originalRequest, Map<String, String> requestHeaders) {
     long startTime = System.currentTimeMillis();
+    String timestampAttributeId = AttributeMetadataUtil.getTimestampAttributeId(
+        metadataProvider, new RequestContext(tenantId, requestHeaders), originalRequest.getEntityType());
+
     // Set the size for percentiles in order by if it is not set. This is to give UI the time to fix
     // the bug which does not set the size when they have order by in the request.
     originalRequest = OrderByPercentileSizeSetter.setPercentileSize(originalRequest);
@@ -116,6 +120,7 @@ public class EntityService {
             originalRequest.getStartTimeMillis(),
             originalRequest.getEndTimeMillis(),
             originalRequest.getEntityType(),
+            timestampAttributeId,
             requestHeaders);
     EntitiesRequest preProcessedRequest =
         requestPreProcessor.transform(originalRequest, entitiesRequestContext);

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionContext.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionContext.java
@@ -81,6 +81,10 @@ public class ExecutionContext {
     return entitiesRequestContext.getTenantId();
   }
 
+  public String getTimestampAttributeId() {
+    return entitiesRequestContext.getTimestampAttributeId();
+  }
+
   public EntitiesRequest getEntitiesRequest() {
     return entitiesRequest;
   }

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilder.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilder.java
@@ -231,6 +231,10 @@ public class ExecutionTreeBuilder {
         executionContext.getSourceToOrderByExpressionMap().values().stream()
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
+    if (orderByExpressions.isEmpty() && executionContext.getEntitiesRequest().getLimit() == 0) {
+      return childNode;
+    }
+
     executionContext.setSortAndPaginationNodeAdded(true);
     return new SortAndPaginateNode(
         childNode,

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitor.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitor.java
@@ -120,6 +120,7 @@ public class ExecutionVisitor implements Visitor<EntityFetcherResponse> {
             request.getStartTimeMillis(),
             request.getEndTimeMillis(),
             request.getEntityType(),
+            executionContext.getTimestampAttributeId(),
             executionContext.getRequestHeaders());
     return entityFetcher.getEntities(context, request);
   }
@@ -153,7 +154,8 @@ public class ExecutionVisitor implements Visitor<EntityFetcherResponse> {
     }
 
     // Construct the filter from the child nodes result
-    Filter filter = constructFilterFromChildNodesResult(childNodeResponse);
+    final Filter filter = constructFilterFromChildNodesResult(childNodeResponse);
+
     // Select attributes, metric aggregations and time-series data from corresponding sources
     List<EntityFetcherResponse> resultMapList = new ArrayList<>();
     // if data are coming from multiple sources, then, get entities and aggregated metrics
@@ -176,6 +178,7 @@ public class ExecutionVisitor implements Visitor<EntityFetcherResponse> {
                       request.getStartTimeMillis(),
                       request.getEndTimeMillis(),
                       request.getEntityType(),
+                      executionContext.getTimestampAttributeId(),
                       executionContext.getRequestHeaders());
               return entityFetcher.getEntities(context, request);
             })
@@ -199,6 +202,7 @@ public class ExecutionVisitor implements Visitor<EntityFetcherResponse> {
                           request.getStartTimeMillis(),
                           request.getEndTimeMillis(),
                           request.getEntityType(),
+                          executionContext.getTimestampAttributeId(),
                           executionContext.getRequestHeaders());
                   return entityFetcher.getAggregatedMetrics(context, request);
                 })
@@ -222,6 +226,7 @@ public class ExecutionVisitor implements Visitor<EntityFetcherResponse> {
                           request.getStartTimeMillis(),
                           request.getEndTimeMillis(),
                           request.getEntityType(),
+                          executionContext.getTimestampAttributeId(),
                           executionContext.getRequestHeaders());
                   return entityFetcher.getTimeAggregatedMetrics(requestContext, request);
                 })
@@ -325,6 +330,7 @@ public class ExecutionVisitor implements Visitor<EntityFetcherResponse> {
             request.getStartTimeMillis(),
             request.getEndTimeMillis(),
             request.getEntityType(),
+            executionContext.getTimestampAttributeId(),
             executionContext.getRequestHeaders());
 
     String source = selectionAndFilterNode.getSource();

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitor.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitor.java
@@ -156,6 +156,9 @@ public class ExecutionVisitor implements Visitor<EntityFetcherResponse> {
     // Construct the filter from the child nodes result
     final Filter filter = constructFilterFromChildNodesResult(childNodeResponse);
 
+    // Set the total entities count in the execution context
+    executionContext.setTotal(childNodeResponse.getEntityKeyBuilderMap().size());
+
     // Select attributes, metric aggregations and time-series data from corresponding sources
     List<EntityFetcherResponse> resultMapList = new ArrayList<>();
     // if data are coming from multiple sources, then, get entities and aggregated metrics

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/QueryServiceRequestAndResponseUtils.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/QueryServiceRequestAndResponseUtils.java
@@ -53,6 +53,16 @@ public class QueryServiceRequestAndResponseUtils {
     return resultSetChunkBuilder.build();
   }
 
+  public static Expression createQsAggregationExpression(String functionName, String functionAlias, String columnName, String columnAlias) {
+    return Expression.newBuilder()
+        .setFunction(Function.newBuilder()
+            .setFunctionName(functionName)
+            .setAlias(functionAlias)
+            .addArguments(createQsColumnExpression(columnName, columnAlias))
+        )
+        .build();
+  }
+
   public static Expression createQsAggregationExpression(String functionName, String columnName, String alias) {
     return Expression.newBuilder()
         .setFunction(Function.newBuilder()
@@ -99,6 +109,19 @@ public class QueryServiceRequestAndResponseUtils {
                     Value.newBuilder()
                         .setString(val)
                         .setValueType(ValueType.STRING)
+                )
+        )
+        .build();
+  }
+
+  public static Expression createQsStringListLiteralExpression(List<String> list) {
+    return Expression.newBuilder()
+        .setLiteral(
+            LiteralConstant.newBuilder()
+                .setValue(
+                    Value.newBuilder()
+                        .addAllStringArray(list)
+                        .setValueType(ValueType.STRING_ARRAY)
                 )
         )
         .build();
@@ -167,7 +190,7 @@ public class QueryServiceRequestAndResponseUtils {
         .build();
   }
 
-  private static Filter createQsTimeRangeFilter(String timestampColumnName, long startTime, long endTime) {
+  public static Filter createQsTimeRangeFilter(String timestampColumnName, long startTime, long endTime) {
     return Filter.newBuilder()
         .setOperator(Operator.AND)
         .addChildFilter(

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/QueryServiceRequestAndResponseUtils.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/QueryServiceRequestAndResponseUtils.java
@@ -140,16 +140,13 @@ public class QueryServiceRequestAndResponseUtils {
     return Filter.newBuilder()
         .setOperator(Operator.AND)
         .addChildFilter(
-            Filter.newBuilder()
-                .setOperator(Operator.AND)
-                .addChildFilter(createQsTimeRangeFilter(timestampColumnName, startTime, endTime))
-                .addChildFilter(requestFilter)
-        )
-        .addChildFilter(
             createQsFilter(createQsColumnExpression(entityIdColumnName),
                 Operator.NEQ,
                 createQsStringLiteralExpression("null"))
         )
+        .addChildFilter(Filter.newBuilder().setOperator(Operator.AND)
+            .addChildFilter(createQsTimeRangeFilter(timestampColumnName, startTime, endTime))
+            .addChildFilter(requestFilter))
         .build();
   }
 
@@ -159,7 +156,6 @@ public class QueryServiceRequestAndResponseUtils {
                                                     long endTime) {
     return Filter.newBuilder()
         .setOperator(Operator.AND)
-        .addChildFilter(createQsTimeRangeFilter(timestampColumnName, startTime, endTime))
         .addChildFilter(
             createQsFilter(
                 createQsColumnExpression(entityIdColumnName),
@@ -167,6 +163,7 @@ public class QueryServiceRequestAndResponseUtils {
                 createQsStringLiteralExpression("null")
             )
         )
+        .addChildFilter(createQsTimeRangeFilter(timestampColumnName, startTime, endTime))
         .build();
   }
 

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/EntityDataServiceEntityFetcherTests.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/EntityDataServiceEntityFetcherTests.java
@@ -13,14 +13,12 @@ import org.junit.jupiter.api.Test;
 
 public class EntityDataServiceEntityFetcherTests {
   private EntityDataServiceEntityFetcher entityDataServiceEntityFetcher;
-  private EntityQueryServiceClient entityQueryServiceClient;
-  private AttributeMetadataProvider attributeMetadataProvider;
   private static final String TENANT_ID = "tenant-id";
 
   @BeforeEach
   public void setup() {
-    entityQueryServiceClient = mock(EntityQueryServiceClient.class);
-    attributeMetadataProvider = mock(AttributeMetadataProvider.class);
+    EntityQueryServiceClient entityQueryServiceClient = mock(EntityQueryServiceClient.class);
+    AttributeMetadataProvider attributeMetadataProvider = mock(AttributeMetadataProvider.class);
     entityDataServiceEntityFetcher =
         new EntityDataServiceEntityFetcher(entityQueryServiceClient, attributeMetadataProvider);
   }
@@ -29,7 +27,7 @@ public class EntityDataServiceEntityFetcherTests {
   public void test_getEntitiesAndAggregatedMetrics() {
     assertThrows(UnsupportedOperationException.class, () -> {
       entityDataServiceEntityFetcher.getEntitiesAndAggregatedMetrics(
-          new EntitiesRequestContext(TENANT_ID, 0, 1, "API", Map.of()),
+          new EntitiesRequestContext(TENANT_ID, 0, 1, "API", "API.startTime", Map.of()),
           EntitiesRequest.newBuilder().build()
       );
     });
@@ -39,7 +37,7 @@ public class EntityDataServiceEntityFetcherTests {
   public void test_getTotalEntities() {
     assertThrows(UnsupportedOperationException.class, () -> {
       entityDataServiceEntityFetcher.getTotalEntities(
-          new EntitiesRequestContext(TENANT_ID, 0, 1, "API", Map.of()),
+          new EntitiesRequestContext(TENANT_ID, 0, 1, "API", "API.startTime", Map.of()),
           EntitiesRequest.newBuilder().build()
       );
     });
@@ -49,7 +47,7 @@ public class EntityDataServiceEntityFetcherTests {
   public void test_getAggregatedMetrics() {
     assertThrows(UnsupportedOperationException.class, () -> {
       entityDataServiceEntityFetcher.getAggregatedMetrics(
-          new EntitiesRequestContext(TENANT_ID, 0, 1, "API", Map.of()),
+          new EntitiesRequestContext(TENANT_ID, 0, 1, "API", "API.startTime", Map.of()),
           EntitiesRequest.newBuilder().build()
       );
     });
@@ -59,7 +57,7 @@ public class EntityDataServiceEntityFetcherTests {
   public void test_getTimeAggregatedMetrics() {
     assertThrows(UnsupportedOperationException.class, () -> {
       entityDataServiceEntityFetcher.getTimeAggregatedMetrics(
-          new EntitiesRequestContext(TENANT_ID, 0, 1, "API", Map.of()),
+          new EntitiesRequestContext(TENANT_ID, 0, 1, "API", "API.startTime", Map.of()),
           EntitiesRequest.newBuilder().build()
       );
     });

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
@@ -22,8 +22,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.util.JsonFormat;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.util.List;
@@ -157,11 +155,6 @@ public class QueryServiceEntityFetcherTests {
             )
     );
 
-    try {
-      System.out.println("Expected: " + JsonFormat.printer().omittingInsignificantWhitespace().print(expectedQueryRequest));
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
-    }
     Map<EntityKey, Builder> expectedEntityKeyBuilderResponseMap = Map.of(
         EntityKey.of("api-id-0"), Entity.newBuilder()
             .setEntityType(AttributeScope.API.name())

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
@@ -22,6 +22,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.util.List;
@@ -84,7 +86,7 @@ public class QueryServiceEntityFetcherTests {
   @Test
   public void test_getEntitiesAndAggregatedMetrics() {
     List<OrderByExpression> orderByExpressions = List.of(buildOrderByExpression(API_ID_ATTR));
-    long startTime = 0L;
+    long startTime = 1L;
     long endTime = 10L;
     int limit = 10;
     int offset = 0;
@@ -112,6 +114,7 @@ public class QueryServiceEntityFetcherTests {
         startTime,
         endTime,
         entityType.name(),
+        "API.startTime",
         requestHeaders);
 
     QueryRequest expectedQueryRequest = QueryRequest.newBuilder()
@@ -154,6 +157,11 @@ public class QueryServiceEntityFetcherTests {
             )
     );
 
+    try {
+      System.out.println("Expected: " + JsonFormat.printer().omittingInsignificantWhitespace().print(expectedQueryRequest));
+    } catch (InvalidProtocolBufferException e) {
+      e.printStackTrace();
+    }
     Map<EntityKey, Builder> expectedEntityKeyBuilderResponseMap = Map.of(
         EntityKey.of("api-id-0"), Entity.newBuilder()
             .setEntityType(AttributeScope.API.name())
@@ -188,7 +196,7 @@ public class QueryServiceEntityFetcherTests {
   @Test
   public void test_getTotalEntitiesSingleEntityIdAttribute() {
     List<OrderByExpression> orderByExpressions = List.of(buildOrderByExpression(API_ID_ATTR));
-    long startTime = 0L;
+    long startTime = 1L;
     long endTime = 10L;
     int limit = 10;
     int offset = 0;
@@ -217,6 +225,7 @@ public class QueryServiceEntityFetcherTests {
         startTime,
         endTime,
         entityType.name(),
+        "API.startTime",
         requestHeaders);
 
     QueryRequest expectedQueryRequest = QueryRequest.newBuilder()

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/transformer/RequestPreProcessorTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/transformer/RequestPreProcessorTest.java
@@ -56,16 +56,18 @@ public class RequestPreProcessorTest {
   @Test
   public void testServiceEntitiesRequestDuplicateColumnSelectionIsRemoved() {
     initializeDomainObjectConfigs("configs/request-preprocessor-test/service-id-config.conf");
+    long endTime = System.currentTimeMillis();
+    long startTime = endTime - 1000L;
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TEST_TENANT_ID, 0L, 1L, "SERVICE", Map.of());
+        new EntitiesRequestContext(TEST_TENANT_ID, startTime, endTime, "SERVICE", "SERVICE.startTime", Map.of());
     mockAttributeMetadata(entitiesRequestContext, AttributeScope.SERVICE.name(), "id");
     mockAttributeMetadata(entitiesRequestContext, AttributeScope.SERVICE.name(), "startTime");
 
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("SERVICE")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 GatewayExpressionCreator.createFilter(
                     QueryExpressionUtil.getColumnExpression("SERVICE.name"),
@@ -94,8 +96,8 @@ public class RequestPreProcessorTest {
     Assertions.assertEquals(
         EntitiesRequest.newBuilder()
             .setEntityType("SERVICE")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 Filter.newBuilder()
                     .setOperator(Operator.AND)
@@ -104,8 +106,8 @@ public class RequestPreProcessorTest {
                             QueryExpressionUtil.getColumnExpression("SERVICE.name"),
                             Operator.LIKE,
                             QueryExpressionUtil.getLiteralExpression("log")))
-                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, 0L))
-                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, 1L))
+                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, startTime))
+                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, endTime))
             )
             .addSelection(QueryExpressionUtil.getColumnExpression("SERVICE.id"))
             .addSelection(QueryExpressionUtil.getColumnExpression("SERVICE.name"))
@@ -125,16 +127,18 @@ public class RequestPreProcessorTest {
   @Test
   public void testDomainEntitiesRequestWithLikeFilterIsTransformed() {
     initializeDomainObjectConfigs("configs/request-preprocessor-test/domains-config.conf");
+    long endTime = System.currentTimeMillis();
+    long startTime = endTime - 1000L;
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TEST_TENANT_ID, 0L, 1L, "EVENT", Map.of());
+        new EntitiesRequestContext(TEST_TENANT_ID, startTime, endTime, "EVENT", "SERVICE.startTime", Map.of());
     // Mock calls into attributeMetadataProvider
     mockAttributeMetadataForDomainAndMappings(entitiesRequestContext);
 
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("EVENT")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 GatewayExpressionCreator.createFilter(
                     QueryExpressionUtil.getColumnExpression("EVENT.name"),
@@ -163,8 +167,8 @@ public class RequestPreProcessorTest {
     Assertions.assertEquals(
         EntitiesRequest.newBuilder()
             .setEntityType("EVENT")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 Filter.newBuilder()
                     .setOperator(Operator.AND)
@@ -180,8 +184,8 @@ public class RequestPreProcessorTest {
                                 QueryExpressionUtil.getColumnExpression("SERVICE.hostHeader"),
                                 Operator.LIKE,
                                 QueryExpressionUtil.getLiteralExpression("log")))
-                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, 0L))
-                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, 1L))
+                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, startTime))
+                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, endTime))
                     )
             )
             .addSelection(QueryExpressionUtil.getColumnExpression("SERVICE.hostHeader"))
@@ -203,16 +207,18 @@ public class RequestPreProcessorTest {
   @Test
   public void testDomainEntitiesRequestWithNeqFilterIsTransformed() {
     initializeDomainObjectConfigs("configs/request-preprocessor-test/domains-config.conf");
+    long endTime = System.currentTimeMillis();
+    long startTime = endTime - 1000L;
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TEST_TENANT_ID, 0L, 1L, "EVENT", Map.of());
+        new EntitiesRequestContext(TEST_TENANT_ID, startTime, endTime, "EVENT", "SERVICE.startTime", Map.of());
     // Mock calls into attributeMetadataProvider
     mockAttributeMetadataForDomainAndMappings(entitiesRequestContext);
 
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("EVENT")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 GatewayExpressionCreator.createFilter(
                     QueryExpressionUtil.getColumnExpression("EVENT.name"),
@@ -235,8 +241,8 @@ public class RequestPreProcessorTest {
     EntitiesRequest expectedRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("EVENT")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 Filter.newBuilder()
                     .setOperator(Operator.AND)
@@ -255,8 +261,8 @@ public class RequestPreProcessorTest {
                                 Operator.NEQ,
                                 QueryExpressionUtil.getLiteralExpression(
                                     "some-entity-name")))
-                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, 0L))
-                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, 1L))
+                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, startTime))
+                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, endTime))
                     )
             )
             .addSelection(QueryExpressionUtil.getColumnExpression("SERVICE.hostHeader"))
@@ -275,16 +281,18 @@ public class RequestPreProcessorTest {
   @Test
   public void testDomainEntitiesRequestWithServiceIdFilterIsNotTransformed() {
     initializeDomainObjectConfigs("configs/request-preprocessor-test/domains-config.conf");
+    long endTime = System.currentTimeMillis();
+    long startTime = endTime - 1000L;
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TEST_TENANT_ID, 0L, 1L, "SERVICE", Map.of());
+        new EntitiesRequestContext(TEST_TENANT_ID, startTime, endTime, "SERVICE", "SERVICE.startTime", Map.of());
     // Mock calls into attributeMetadataProvider
     mockAttributeMetadataForDomainAndMappings(entitiesRequestContext);
 
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("SERVICE")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 GatewayExpressionCreator.createFilter(
                     QueryExpressionUtil.getColumnExpression("SERVICE.id"),
@@ -299,8 +307,8 @@ public class RequestPreProcessorTest {
     EntitiesRequest expectedRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("SERVICE")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 Filter.newBuilder()
                     .setOperator(Operator.AND)
@@ -311,8 +319,8 @@ public class RequestPreProcessorTest {
                             createStringArrayLiteralExpressionBuilder(List.of("service1-id", "service2-id"))
                         )
                     )
-                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, 0L))
-                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, 1L))
+                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, startTime))
+                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, endTime))
             )
             .addSelection(QueryExpressionUtil.getColumnExpression("SERVICE.id"))
             .build();
@@ -326,16 +334,18 @@ public class RequestPreProcessorTest {
   @Test
   public void testDomainEntitiesRequestWithInFilterIsTransformed() {
     initializeDomainObjectConfigs("configs/request-preprocessor-test/domains-config.conf");
+    long endTime = System.currentTimeMillis();
+    long startTime = endTime - 1000L;
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TEST_TENANT_ID, 0L, 1L, "EVENT", Map.of());
+        new EntitiesRequestContext(TEST_TENANT_ID, startTime, endTime, "EVENT", "SERVICE.startTime", Map.of());
     // Mock calls into attributeMetadataProvider
     mockAttributeMetadataForDomainAndMappings(entitiesRequestContext);
 
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("SERVICE")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 GatewayExpressionCreator.createFilter(
                     QueryExpressionUtil.getColumnExpression("SERVICE.mappedAttr1"),
@@ -352,8 +362,8 @@ public class RequestPreProcessorTest {
     Assertions.assertEquals(
         EntitiesRequest.newBuilder()
             .setEntityType("SERVICE")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 Filter.newBuilder()
                     .setOperator(Operator.AND)
@@ -401,8 +411,8 @@ public class RequestPreProcessorTest {
                                     )
                             )
                     )
-                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, 0L))
-                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, 1L))
+                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, startTime))
+                    .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, endTime))
             )
             .addSelection(QueryExpressionUtil.getColumnExpression("SERVICE.attr1"))
             .addSelection(QueryExpressionUtil.getColumnExpression("SERVICE.attr2"))
@@ -414,16 +424,18 @@ public class RequestPreProcessorTest {
   @Test
   public void testDomainEntitiesRequestWithEqFilterIsTransformed() {
     initializeDomainObjectConfigs("configs/request-preprocessor-test/domains-config.conf");
+    long endTime = System.currentTimeMillis();
+    long startTime = endTime - 1000L;
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TEST_TENANT_ID, 0L, 1L, "EVENT", Map.of());
+        new EntitiesRequestContext(TEST_TENANT_ID, startTime, endTime, "EVENT", "SERVICE.startTime", Map.of());
     // Mock calls into attributeMetadataProvider
     mockAttributeMetadataForDomainAndMappings(entitiesRequestContext);
 
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("SERVICE")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 GatewayExpressionCreator.createFilter(
                     QueryExpressionUtil.getColumnExpression("SERVICE.mappedAttr2"),
@@ -442,8 +454,8 @@ public class RequestPreProcessorTest {
     Assertions.assertEquals(
         EntitiesRequest.newBuilder()
             .setEntityType("SERVICE")
-            .setStartTimeMillis(0L)
-            .setEndTimeMillis(1L)
+            .setStartTimeMillis(startTime)
+            .setEndTimeMillis(endTime)
             .setFilter(
                 Filter.newBuilder()
                     .setOperator(Operator.AND)
@@ -464,8 +476,8 @@ public class RequestPreProcessorTest {
                                     GatewayExpressionCreator.createLiteralExpression("attr10_val20")
                                 )
                             )
-                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, 0L))
-                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, 1L))
+                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.GE, startTime))
+                            .addChildFilter(EntitiesRequestAndResponseUtils.getTimestampFilter("SERVICE.startTime", Operator.LT, endTime))
                     )
             )
             .addSelection(QueryExpressionUtil.getColumnExpression("SERVICE.mappedAttr2"))

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/EntitiesRequestResponseProcessorTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/EntitiesRequestResponseProcessorTest.java
@@ -70,8 +70,10 @@ public class EntitiesRequestResponseProcessorTest {
 
   @Test
   public void testEntitiesRequestTransform() {
+    EntitiesRequestContext context = mock(EntitiesRequestContext.class);
+    when(context.getTimestampAttributeId()).thenReturn("API.startTime");
     EntitiesRequest transformedRequest =
-        requestPreProcessor.transform(originalRequest, mock(EntitiesRequestContext.class));
+        requestPreProcessor.transform(originalRequest, context);
     List<Expression> expressionList = transformedRequest.getSelectionList();
     Assertions.assertEquals(3, expressionList.size());
     Assertions.assertTrue(
@@ -92,8 +94,12 @@ public class EntitiesRequestResponseProcessorTest {
             .contains("API.apiId"));
 
     Filter filter = transformedRequest.getFilter();
-    Assertions.assertEquals(Operator.EQ, filter.getOperator());
-    Assertions.assertEquals(0, filter.getChildFilterCount());
+    Assertions.assertEquals(Operator.AND, filter.getOperator());
+    Assertions.assertEquals(3, filter.getChildFilterCount());
+
+    // Verify the first filter.
+    Assertions.assertEquals(Operator.EQ, filter.getChildFilter(0).getOperator());
+    Assertions.assertEquals(0, filter.getChildFilter(0).getChildFilterCount());
   }
 
   @Test
@@ -110,8 +116,9 @@ public class EntitiesRequestResponseProcessorTest {
                     "API.metrics.bytes_received", FunctionType.SUM, "SUM_bytes_received", true))
             .build();
 
-    EntitiesRequest transformedRequest =
-        requestPreProcessor.transform(originalRequest, mock(EntitiesRequestContext.class));
+    EntitiesRequestContext context = mock(EntitiesRequestContext.class);
+    when(context.getTimestampAttributeId()).thenReturn("API.startTime");
+    EntitiesRequest transformedRequest = requestPreProcessor.transform(originalRequest, context);
     List<Expression> expressionList = transformedRequest.getSelectionList();
     Assertions.assertEquals(3, expressionList.size());
   }

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/EntityServiceTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/EntityServiceTest.java
@@ -8,8 +8,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.util.JsonFormat;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.util.Arrays;
@@ -111,7 +109,7 @@ public class EntityServiceTest extends AbstractGatewayServiceTest {
                     .setFqn("API.apiId")
                     .setValueKind(AttributeKind.TYPE_STRING)
                     .setType(AttributeType.ATTRIBUTE)
-                    .addSources(AttributeSource.QS)
+                    .addSources(AttributeSource.QS).addSources(AttributeSource.EDS)
                     .setId("API.apiId")
                     .build(),
                 "API.apiName",
@@ -121,7 +119,7 @@ public class EntityServiceTest extends AbstractGatewayServiceTest {
                     .setFqn("API.name")
                     .setValueKind(AttributeKind.TYPE_STRING)
                     .setType(AttributeType.ATTRIBUTE)
-                    .addSources(AttributeSource.QS)
+                    .addSources(AttributeSource.QS).addSources(AttributeSource.EDS)
                     .setId("API.name")
                     .build(),
                 "API.httpMethod",
@@ -147,7 +145,7 @@ public class EntityServiceTest extends AbstractGatewayServiceTest {
                     .setValueKind(AttributeKind.TYPE_STRING)
                     .setId("API.apiId")
                     .setType(AttributeType.ATTRIBUTE)
-                    .addSources(AttributeSource.QS)
+                    .addSources(AttributeSource.QS).addSources(AttributeSource.EDS)
                     .build()));
     when(
             attributeMetadataProvider.getAttributeMetadata(
@@ -166,7 +164,7 @@ public class EntityServiceTest extends AbstractGatewayServiceTest {
   }
 
   @Test
-  public void testGetEntitiesOnlySelectFromSingleSource() {
+  public void testGetEntitiesOnlySelectFromSingleSourceWithTimeRangeShouldUseQueryService() {
     long endTime = System.currentTimeMillis();
     long startTime = endTime - 1000;
     EntitiesRequest entitiesRequest =
@@ -266,6 +264,8 @@ public class EntityServiceTest extends AbstractGatewayServiceTest {
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
             .setEntityType("API")
+            .setStartTimeMillis(System.currentTimeMillis() - 1000)
+            .setEndTimeMillis(System.currentTimeMillis())
             .setFilter(org.hypertrace.gateway.service.v1.common.Filter.newBuilder()
                 .setOperator(Operator.IN)
                 .setLhs(getExpressionFor("API.httpMethod", "API Http method"))

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilderTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilderTest.java
@@ -136,7 +136,7 @@ public class ExecutionTreeBuilderTest {
         .setFilter(getTimeRangeFilter("API.startTime", startTime, endTime))
         .build();
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TENANT_ID, startTime, endTime, "API", new HashMap<>());
+        new EntitiesRequestContext(TENANT_ID, startTime, endTime, "API", "API.startTime", new HashMap<>());
     ExecutionContext executionContext =
         ExecutionContext.from(attributeMetadataProvider, entitiesRequest, entitiesRequestContext);
     return new ExecutionTreeBuilder(executionContext);
@@ -401,7 +401,7 @@ public class ExecutionTreeBuilderTest {
               .setOffset(20)
               .build();
       EntitiesRequestContext entitiesRequestContext =
-          new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", new HashMap<>());
+          new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", "API.startTime", new HashMap<>());
       ExecutionContext executionContext =
           ExecutionContext.from(attributeMetadataProvider, entitiesRequest, entitiesRequestContext);
       ExecutionTreeBuilder executionTreeBuilder = new ExecutionTreeBuilder(executionContext);
@@ -433,7 +433,7 @@ public class ExecutionTreeBuilderTest {
               .setOffset(0)
               .build();
       EntitiesRequestContext entitiesRequestContext =
-          new EntitiesRequestContext(TENANT_ID, startTime, endTime, "API", new HashMap<>());
+          new EntitiesRequestContext(TENANT_ID, startTime, endTime, "API", "API.startTime", new HashMap<>());
       ExecutionContext executionContext =
           ExecutionContext.from(attributeMetadataProvider, entitiesRequest, entitiesRequestContext);
       ExecutionTreeBuilder executionTreeBuilder = new ExecutionTreeBuilder(executionContext);
@@ -465,7 +465,7 @@ public class ExecutionTreeBuilderTest {
             .setOffset(20)
             .build();
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", new HashMap<>());
+        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", "API.startTime", new HashMap<>());
     ExecutionContext executionContext =
         ExecutionContext.from(attributeMetadataProvider, entitiesRequest, entitiesRequestContext);
     ExecutionTreeBuilder executionTreeBuilder = new ExecutionTreeBuilder(executionContext);
@@ -497,7 +497,7 @@ public class ExecutionTreeBuilderTest {
             .setOffset(0)
             .build();
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", new HashMap<>());
+        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", "API.startTime", new HashMap<>());
     ExecutionContext executionContext =
         ExecutionContext.from(attributeMetadataProvider, entitiesRequest, entitiesRequestContext);
     ExecutionTreeBuilder executionTreeBuilder = new ExecutionTreeBuilder(executionContext);
@@ -547,7 +547,7 @@ public class ExecutionTreeBuilderTest {
             .setOffset(0)
             .build();
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", new HashMap<>());
+        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", "API.startTime", new HashMap<>());
     ExecutionContext executionContext =
         ExecutionContext.from(attributeMetadataProvider, entitiesRequest, entitiesRequestContext);
     ExecutionTreeBuilder executionTreeBuilder = new ExecutionTreeBuilder(executionContext);
@@ -600,7 +600,7 @@ public class ExecutionTreeBuilderTest {
             .setOffset(0)
             .build();
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", new HashMap<>());
+        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", "API.startTime", new HashMap<>());
     ExecutionContext executionContext =
         ExecutionContext.from(attributeMetadataProvider, entitiesRequest, entitiesRequestContext);
     ExecutionTreeBuilder executionTreeBuilder = new ExecutionTreeBuilder(executionContext);
@@ -655,7 +655,7 @@ public class ExecutionTreeBuilderTest {
             .setOffset(0)
             .build();
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", new HashMap<>());
+        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", "API.startTime", new HashMap<>());
     ExecutionContext executionContext =
         ExecutionContext.from(attributeMetadataProvider, entitiesRequest, entitiesRequestContext);
     ExecutionTreeBuilder executionTreeBuilder = new ExecutionTreeBuilder(executionContext);
@@ -698,7 +698,7 @@ public class ExecutionTreeBuilderTest {
             .setOffset(10)
             .build();
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", new HashMap<>());
+        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", "API.startTime", new HashMap<>());
     ExecutionContext executionContext =
         ExecutionContext.from(attributeMetadataProvider, entitiesRequest, entitiesRequestContext);
     ExecutionTreeBuilder executionTreeBuilder = new ExecutionTreeBuilder(executionContext);
@@ -736,7 +736,7 @@ public class ExecutionTreeBuilderTest {
             .build();
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(TENANT_ID, entitiesRequest.getStartTimeMillis(), entitiesRequest.getEndTimeMillis(),
-            "API", new HashMap<>());
+            "API", "API.startTime", new HashMap<>());
     ExecutionContext executionContext =
         ExecutionContext.from(attributeMetadataProvider, entitiesRequest, entitiesRequestContext);
     ExecutionTreeBuilder executionTreeBuilder = new ExecutionTreeBuilder(executionContext);
@@ -771,7 +771,7 @@ public class ExecutionTreeBuilderTest {
                     List.of()))
             .build();
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", new HashMap<>());
+        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", "API.startTime", new HashMap<>());
     ExecutionContext executionContext =
         ExecutionContext.from(attributeMetadataProvider, entitiesRequest, entitiesRequestContext);
     ExecutionTreeBuilder executionTreeBuilder = new ExecutionTreeBuilder(executionContext);

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilderTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilderTest.java
@@ -780,10 +780,8 @@ public class ExecutionTreeBuilderTest {
     assertTrue(executionTree instanceof SelectionNode);
     assertTrue(((SelectionNode) executionTree).getAggMetricSelectionSources().contains(AttributeSource.QS.name()));
     QueryNode firstChild = ((SelectionNode) executionTree).getChildNode();
-    assertTrue(firstChild instanceof SortAndPaginateNode);
-    QueryNode secondChild = ((SortAndPaginateNode) firstChild).getChildNode();
-    assertTrue(secondChild instanceof DataFetcherNode);
-    assertEquals(AttributeSource.EDS.name(), ((DataFetcherNode) secondChild).getSource());
+    assertTrue(firstChild instanceof DataFetcherNode);
+    assertEquals(AttributeSource.EDS.name(), ((DataFetcherNode) firstChild).getSource());
   }
 
   private void mockDomainObjectConfigs() {

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitorTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitorTest.java
@@ -365,6 +365,7 @@ public class ExecutionVisitorTest {
         startTime,
         endTime,
         entityType.name(),
+        "API.startTime",
         requestHeaders);
     Map<EntityKey, Builder> entityKeyBuilderResponseMap = Map.of(
         EntityKey.of("entity-id-0"), Entity.newBuilder().putAttribute("API.name", getStringValue("entity-0")),
@@ -375,6 +376,7 @@ public class ExecutionVisitorTest {
     when(executionContext.getEntitiesRequest()).thenReturn(entitiesRequest);
     when(executionContext.getTenantId()).thenReturn(tenantId);
     when(executionContext.getRequestHeaders()).thenReturn(requestHeaders);
+    when(executionContext.getTimestampAttributeId()).thenReturn("API.startTime");
     when(queryServiceEntityFetcher.getEntitiesAndAggregatedMetrics(eq(entitiesRequestContext), eq(entitiesRequest)))
         .thenReturn(entityFetcherResponse);
     when(queryServiceEntityFetcher.getTimeAggregatedMetrics(eq(entitiesRequestContext), eq(entitiesRequest)))
@@ -411,6 +413,7 @@ public class ExecutionVisitorTest {
         startTime,
         endTime,
         entityType.name(),
+        "API.startTime",
         requestHeaders);
     Map<EntityKey, Builder> entityKeyBuilderResponseMap = Map.of(
         EntityKey.of("entity-id-0"), Entity.newBuilder().putAttribute("API.name", getStringValue("entity-0")),
@@ -421,6 +424,7 @@ public class ExecutionVisitorTest {
     when(executionContext.getEntitiesRequest()).thenReturn(entitiesRequest);
     when(executionContext.getTenantId()).thenReturn(tenantId);
     when(executionContext.getRequestHeaders()).thenReturn(requestHeaders);
+    when(executionContext.getTimestampAttributeId()).thenReturn("API.startTime");
     when(entityDataServiceEntityFetcher.getEntities(eq(entitiesRequestContext), eq(entitiesRequest)))
         .thenReturn(entityFetcherResponse);
 
@@ -457,6 +461,7 @@ public class ExecutionVisitorTest {
         startTime,
         endTime,
         entityType.name(),
+        "API.startTime",
         requestHeaders);
     Map<EntityKey, Builder> entityKeyBuilderResponseMap1 = Map.of(
         EntityKey.of("entity-id-0"), Entity.newBuilder()
@@ -493,6 +498,7 @@ public class ExecutionVisitorTest {
     when(executionContext.getEntitiesRequest()).thenReturn(entitiesRequest);
     when(executionContext.getTenantId()).thenReturn(tenantId);
     when(executionContext.getRequestHeaders()).thenReturn(requestHeaders);
+    when(executionContext.getTimestampAttributeId()).thenReturn("API.startTime");
     when(queryServiceEntityFetcher.getEntitiesAndAggregatedMetrics(eq(entitiesRequestContext), eq(entitiesRequest)))
         .thenReturn(new EntityFetcherResponse(entityKeyBuilderResponseMap1));
     when(queryServiceEntityFetcher.getTimeAggregatedMetrics(eq(entitiesRequestContext), eq(entitiesRequest)))
@@ -532,6 +538,7 @@ public class ExecutionVisitorTest {
         startTime,
         endTime,
         entityType.name(),
+        "API.startTime",
         requestHeaders);
 
     // Order matters since we will do the pagination ourselves. So we use a LinkedHashMap
@@ -581,6 +588,7 @@ public class ExecutionVisitorTest {
     when(executionContext.getEntitiesRequest()).thenReturn(entitiesRequest);
     when(executionContext.getTenantId()).thenReturn(tenantId);
     when(executionContext.getRequestHeaders()).thenReturn(requestHeaders);
+    when(executionContext.getTimestampAttributeId()).thenReturn("API.startTime");
     EntitiesRequest entitiesRequestForEntityFetcher = EntitiesRequest.newBuilder(entitiesRequest)
         .setLimit(limit + offset)
         .setOffset(0)
@@ -626,6 +634,7 @@ public class ExecutionVisitorTest {
         startTime,
         endTime,
         entityType.name(),
+        "API.startTime",
         requestHeaders);
     Map<EntityKey, Builder> entityKeyBuilderResponseMap1 = Map.of(
         EntityKey.of("entity-id-0"), Entity.newBuilder()
@@ -662,6 +671,7 @@ public class ExecutionVisitorTest {
     when(executionContext.getEntitiesRequest()).thenReturn(entitiesRequest);
     when(executionContext.getTenantId()).thenReturn(tenantId);
     when(executionContext.getRequestHeaders()).thenReturn(requestHeaders);
+    when(executionContext.getTimestampAttributeId()).thenReturn("API.startTime");
     when(queryServiceEntityFetcher.getEntitiesAndAggregatedMetrics(eq(entitiesRequestContext), eq(entitiesRequest)))
         .thenReturn(new EntityFetcherResponse(entityKeyBuilderResponseMap1));
     when(queryServiceEntityFetcher.getTimeAggregatedMetrics(eq(entitiesRequestContext), eq(entitiesRequest)))
@@ -684,6 +694,7 @@ public class ExecutionVisitorTest {
   public void test_visitSelectionNode_differentSource_callSeparatedCalls() {
     ExecutionVisitor executionVisitor =
         spy(new ExecutionVisitor(executionContext, entityQueryHandlerRegistry));
+    when(executionContext.getTimestampAttributeId()).thenReturn("API.startTime");
     SelectionNode selectionNode = new SelectionNode.Builder(new NoOpNode())
         .setAttrSelectionSources(Set.of(EDS_SOURCE))
         .setAggMetricSelectionSources(Set.of(QS_SOURCE))


### PR DESCRIPTION
## Description
This is fixing a bug where the time range wasn't being passed to query service in the query service requests. You can say this was a bug introduced as part of https://github.com/hypertrace/gateway-service/pull/44 bug fix.

### Testing
Unit testing, tested in real setup and verified that all the query service queries have time range now.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
No functional changes and bug was introduced in this release itself.