### PR TITLE
Revert "updates release workflow"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
           password: $DOCKERHUB_PASSWORD
   helm:
     docker:
-      - image: hypertrace/helm-gcs-packager:0.3.0
+      - image: hypertrace/helm-gcs-packager:0.1.1
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -32,12 +32,16 @@ commands:
       - checkout
       - run:
           name: Generate cache key
-          command: find . -type f -name "*.gradle-wrapper*" -exec shasum {} + | sort > /tmp/checksum.txt && cat /tmp/checksum.txt
+          command: find . -type f -name "*.gradle*" -exec shasum {} + | sort > /tmp/checksum.txt && cat /tmp/checksum.txt
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "/tmp/checksum.txt" }}
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
+      - setup_remote_docker
+      - run:
+          name: Dockerhub login
+          command: echo $DOCKERHUB_PASSWORD | docker login --username $DOCKERHUB_USERNAME --password-stdin
   populate_and_save_cache:
     description: 'Downloads all gradle dependencies and uploads cache for later use'
     steps:
@@ -47,42 +51,29 @@ commands:
           paths:
             - ~/.gradle
           key: v1-dependencies-{{ checksum "/tmp/checksum.txt" }}
-  docker_login:
-    description: "Login to dockerhub with readonly credentials"
-    steps:
-      - run:
-          name: Dockerhub login
-          command: echo $DOCKERHUB_PASSWORD | docker login --username $DOCKERHUB_USERNAME --password-stdin
 
 jobs:
   build:
     executor: gradle_docker
     steps:
       - setup_build_environment
-      - setup_remote_docker: &latest_remote_docker
-          version: 19.03.12
       - populate_and_save_cache
-      - docker_login
       - gradle:
           args: build dockerBuildImages
       - gradle:
           args: jacocoTestReport
       - codecov/upload:
           flags: unit
-  merge-publish:
+  publish:
     executor: gradle_docker
     steps:
       - setup_build_environment
-      - setup_remote_docker: *latest_remote_docker
-      - docker_login
       - gradle:
-          args: dockerPushImages
-  release-publish:
-    executor: gradle_docker
-    steps:
-      - setup_build_environment
-      - setup_remote_docker: *latest_remote_docker
-      - docker_login
+          args: :tag -Prelease
+      - add_ssh_keys:
+          fingerprints:
+            - '9e:5e:1b:28:cf:14:d6:7d:cd:48:64:72:d0:6f:01:c8'
+      - run: git push origin $(./gradlew -q :printVersion)
       - gradle:
           args: publish dockerPushImages
   validate-charts:
@@ -103,20 +94,10 @@ jobs:
       - setup_build_environment
       - snyk/scan:
           additional-arguments: --all-sub-projects --policy-path=.snyk
-  release-charts:
+  package-charts:
     executor: helm
-    working_directory: ~/repo
     steps:
       - checkout
-      - run:
-          name: Add release tag
-          command: |
-            git config --global user.email "${CIRCLE_USERNAME}@hypertrace.org"
-            git config --global user.name "$CIRCLE_USERNAME"
-            git tag -am "Released by $CIRCLE_USERNAME" $(git describe --abbrev=0 --tags | sed 's/^release-//')
-      - run:
-          name: Remove trigger tag
-          command: git tag -d release-$(git describe --abbrev=0)
       - run:
           name: Package and Publish Helm Charts
           # Read the "name:" from Chart.yaml. The chart version is <chart-name>-<semver git tag>
@@ -125,17 +106,9 @@ jobs:
             CHART_NAME=$(awk '/^name:/ {print $2}' ./helm/Chart.yaml)
             export GOOGLE_APPLICATION_CREDENTIALS=${HOME}/helm-gcs-key.json
             echo ${HELM_GCS_CREDENTIALS} > ${GOOGLE_APPLICATION_CREDENTIALS}
-            helm dependency update ./helm/
             helm repo add helm-gcs ${HELM_GCS_REPOSITORY}
             helm package --version ${CHART_VERSION} --app-version ${CHART_VERSION} ./helm/
             helm gcs push ${CHART_NAME}-${CHART_VERSION}.tgz helm-gcs --public --retry
-      - add_ssh_keys:
-          fingerprints:
-            # This ssh key gives write permission needed for the following step.
-            - '76:7a:c8:91:c0:cd:eb:71:96:3c:44:c6:cf:b0:26:83'
-      - run:
-          name: Update remote tags
-          command: git push origin refs/tags/$(git describe --abbrev=0) :refs/tags/release-$(git describe --abbrev=0)
 workflows:
   version: 2
   build-and-publish:
@@ -150,7 +123,7 @@ workflows:
           context:
             - hypertrace-vulnerability-scanning
             - dockerhub-read
-      - merge-publish:
+      - publish:
           context:
             - hypertrace-publishing
             - dockerhub-read
@@ -162,23 +135,13 @@ workflows:
             branches:
               only:
                 - main
-      - release-publish:
-          context:
-            - hypertrace-publishing
-            - dockerhub-read
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^release-.*/
-      - release-charts:
+      - package-charts:
           context:
             - hypertrace-publishing
             - dockerhub-read
           requires:
-            - release-publish
+            - publish
           filters:
             branches:
-              ignore: /.*/
-            tags:
-              only: /^release-.*/
+              only:
+                - main


### PR DESCRIPTION
Reverts hypertrace/gateway-service#43

@JBAhire Unfortunately, I've to revert this PR because i've run into the failures like https://app.circleci.com/pipelines/github/hypertrace/gateway-service/246/workflows/eb93b6a6-5465-46d8-832d-174c2f49223b/jobs/718 when charts are being published on release. 
I see that @aaron-steinfeld had some comments on https://github.com/hypertrace/attribute-service/pull/30 and probably you can raise this PR again after addressing the same questions on this PR too? 