### PR TITLE
fix: added missing api_trace id mapping

### DIFF
--- a/gateway-service/src/main/resources/configs/common/application.conf
+++ b/gateway-service/src/main/resources/configs/common/application.conf
@@ -64,6 +64,17 @@ domainobject.config = [
     ]
   },
   {
+    scope = API_TRACE
+    key = apiTraceId
+    primaryKey = true
+    mapping = [
+      {
+        scope = API_TRACE
+        key = apiTraceId
+      }
+    ]
+  },
+  {
     scope = BACKEND
     key = id
     primaryKey = true


### PR DESCRIPTION
## Description
The scope filters are added per scope, based on the domainobject configs defined here https://github.com/hypertrace/gateway-service/blob/main/gateway-service/src/main/resources/configs/common/application.conf#L43

The scope filter added for `API_TRACE` being https://github.com/hypertrace/gateway-service/blob/main/gateway-service/src/main/resources/configs/common/application.conf#L81, were not getting applied, since there were no attribute id mappings defined for the `API_TRACE` scope and hence, the API traces returned did not have the `apiBoundaryType = ENTRY` applied on them


### Testing
Tested end to end manually

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules