### PR TITLE
fix(entities): add missing selections, aggregations or time series

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/transformer/ResponsePostProcessor.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/transformer/ResponsePostProcessor.java
@@ -1,0 +1,71 @@
+package org.hypertrace.gateway.service.common.transformer;
+
+import org.hypertrace.gateway.service.entity.query.ExecutionContext;
+import org.hypertrace.gateway.service.v1.common.AggregatedMetricValue;
+import org.hypertrace.gateway.service.v1.common.MetricSeries;
+import org.hypertrace.gateway.service.v1.common.Value;
+import org.hypertrace.gateway.service.v1.entity.Entity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ResponsePostProcessor {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ResponsePostProcessor.class);
+
+  public List<Entity.Builder> transform(
+      ExecutionContext executionContext, List<Entity.Builder> entityBuilders) {
+    Set<String> selections =
+        executionContext.getSourceToSelectionExpressionMap().values().stream()
+            .flatMap(Collection::stream)
+            .map(expression -> expression.getColumnIdentifier().getAlias())
+            .collect(Collectors.toSet());
+    Set<String> aggregations =
+        executionContext.getSourceToMetricExpressionMap().values().stream()
+            .flatMap(Collection::stream)
+            .map(expression -> expression.getFunction().getAlias())
+            .collect(Collectors.toSet());
+    Set<String> timeAggregations =
+        executionContext.getSourceToTimeAggregationMap().values().stream()
+            .flatMap(Collection::stream)
+            .map(timeAggregation -> timeAggregation.getAggregation().getFunction().getAlias())
+            .collect(Collectors.toSet());
+    for (Entity.Builder entityBuilder : entityBuilders) {
+      // if the number of selections requested does not match for an entity
+      if (entityBuilder.getAttributeCount() != selections.size()) {
+        Set<String> attributeKeySet = entityBuilder.getAttributeMap().keySet();
+        for (String selection : selections) {
+          // if the requested attribute does not exist in the entity, add a default value
+          if (!attributeKeySet.contains(selection)) {
+            entityBuilder.putAttribute(selection, Value.getDefaultInstance());
+          }
+        }
+      }
+
+      if (entityBuilder.getMetricCount() != aggregations.size()) {
+        Set<String> metricKeySet = entityBuilder.getMetricMap().keySet();
+        for (String aggregation : aggregations) {
+          // if the requested aggregation does not exist in the entity, add a default value
+          if (!metricKeySet.contains(aggregation)) {
+            entityBuilder.putMetric(aggregation, AggregatedMetricValue.getDefaultInstance());
+          }
+        }
+      }
+
+      if (entityBuilder.getMetricSeriesCount() != timeAggregations.size()) {
+        Set<String> metricSeriesKeySet = entityBuilder.getMetricSeriesMap().keySet();
+        for (String timeAggregation : timeAggregations) {
+          // if the requested metric series does not exist in the entity, add a default value
+          if (!metricSeriesKeySet.contains(timeAggregation)) {
+            entityBuilder.putMetricSeries(timeAggregation, MetricSeries.getDefaultInstance());
+          }
+        }
+      }
+    }
+
+    return entityBuilders;
+  }
+}

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/transformer/ResponsePostProcessorTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/transformer/ResponsePostProcessorTest.java
@@ -1,0 +1,171 @@
+package org.hypertrace.gateway.service.common.transformer;
+
+import org.hypertrace.gateway.service.entity.query.ExecutionContext;
+import org.hypertrace.gateway.service.v1.common.AggregatedMetricValue;
+import org.hypertrace.gateway.service.v1.common.ColumnIdentifier;
+import org.hypertrace.gateway.service.v1.common.Expression;
+import org.hypertrace.gateway.service.v1.common.FunctionExpression;
+import org.hypertrace.gateway.service.v1.common.Interval;
+import org.hypertrace.gateway.service.v1.common.MetricSeries;
+import org.hypertrace.gateway.service.v1.common.TimeAggregation;
+import org.hypertrace.gateway.service.v1.common.Value;
+import org.hypertrace.gateway.service.v1.entity.Entity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ResponsePostProcessorTest {
+  private ResponsePostProcessor responsePostProcessor;
+
+  @BeforeEach
+  public void setup() {
+    this.responsePostProcessor = new ResponsePostProcessor();
+  }
+
+  @Test
+  public void shouldAddMissingSelections() {
+    ExecutionContext executionContext = mock(ExecutionContext.class);
+    when(executionContext.getSourceToSelectionExpressionMap())
+        .thenReturn(
+            Map.of(
+                "EDS",
+                List.of(createAttributeExpression("API.id"), createAttributeExpression("API.name")),
+                "QS",
+                List.of(createAttributeExpression("API.serviceId"))));
+    when(executionContext.getSourceToMetricExpressionMap()).thenReturn(Collections.emptyMap());
+    when(executionContext.getSourceToTimeAggregationMap()).thenReturn(Collections.emptyMap());
+
+    List<Entity.Builder> entityBuilders =
+        List.of(
+            Entity.newBuilder().putAttribute("API.id", Value.newBuilder().setString("123").build()),
+            Entity.newBuilder()
+                .putAttribute("API.id", Value.newBuilder().setString("234").build())
+                .putAttribute("API.name", Value.newBuilder().setString("api2").build()));
+
+    List<Entity.Builder> postProcessedEntityBuilders =
+        this.responsePostProcessor.transform(executionContext, entityBuilders);
+    assertEquals(2, postProcessedEntityBuilders.size());
+
+    Entity.Builder firstEntityBuilder = postProcessedEntityBuilders.get(0);
+    assertEquals(3, firstEntityBuilder.getAttributeCount());
+    assertEquals(
+        Value.newBuilder().setString("123").build(),
+        firstEntityBuilder.getAttributeMap().get("API.id"));
+    assertEquals(Value.getDefaultInstance(), firstEntityBuilder.getAttributeMap().get("API.name"));
+    assertEquals(
+        Value.getDefaultInstance(), firstEntityBuilder.getAttributeMap().get("API.serviceId"));
+
+    Entity.Builder secondEntityBuilder = postProcessedEntityBuilders.get(1);
+    assertEquals(3, secondEntityBuilder.getAttributeCount());
+    assertEquals(
+        Value.newBuilder().setString("234").build(),
+        secondEntityBuilder.getAttributeMap().get("API.id"));
+    assertEquals(
+        Value.newBuilder().setString("api2").build(),
+        secondEntityBuilder.getAttributeMap().get("API.name"));
+    assertEquals(
+        Value.getDefaultInstance(), secondEntityBuilder.getAttributeMap().get("API.serviceId"));
+  }
+
+  @Test
+  public void shouldAddMissingAggregations() {
+    ExecutionContext executionContext = mock(ExecutionContext.class);
+    when(executionContext.getSourceToSelectionExpressionMap()).thenReturn(Collections.emptyMap());
+    when(executionContext.getSourceToMetricExpressionMap())
+        .thenReturn(Map.of("QS", List.of(createAggregateExpression("API.duration"))));
+    when(executionContext.getSourceToTimeAggregationMap()).thenReturn(Collections.emptyMap());
+
+    List<Entity.Builder> entityBuilders =
+        List.of(
+            Entity.newBuilder()
+                .putMetric(
+                    "API.duration",
+                    AggregatedMetricValue.newBuilder()
+                        .setValue(Value.newBuilder().setLong(1).build())
+                        .build()),
+            Entity.newBuilder());
+
+    List<Entity.Builder> postProcessedEntityBuilders =
+        this.responsePostProcessor.transform(executionContext, entityBuilders);
+    assertEquals(2, postProcessedEntityBuilders.size());
+
+    Entity.Builder firstEntityBuilder = postProcessedEntityBuilders.get(0);
+    assertEquals(1, firstEntityBuilder.getMetricCount());
+    assertEquals(
+        AggregatedMetricValue.newBuilder().setValue(Value.newBuilder().setLong(1).build()).build(),
+        firstEntityBuilder.getMetricMap().get("API.duration"));
+
+    Entity.Builder secondEntityBuilder = postProcessedEntityBuilders.get(1);
+    assertEquals(1, secondEntityBuilder.getMetricCount());
+    assertEquals(
+        AggregatedMetricValue.getDefaultInstance(),
+        secondEntityBuilder.getMetricMap().get("API.duration"));
+  }
+
+  @Test
+  public void shouldAddMissingTimeAggregations() {
+    ExecutionContext executionContext = mock(ExecutionContext.class);
+    when(executionContext.getSourceToSelectionExpressionMap()).thenReturn(Collections.emptyMap());
+    when(executionContext.getSourceToMetricExpressionMap()).thenReturn(Collections.emptyMap());
+    when(executionContext.getSourceToTimeAggregationMap())
+        .thenReturn(Map.of("QS", List.of(createTimeAggregation("API.duration"))));
+
+    List<Entity.Builder> entityBuilders =
+        List.of(
+            Entity.newBuilder()
+                .putMetricSeries(
+                    "API.duration",
+                    MetricSeries.newBuilder()
+                        .addValue(
+                            Interval.newBuilder()
+                                .setValue(Value.newBuilder().setLong(2).build())
+                                .build())
+                        .build()),
+            Entity.newBuilder());
+
+    List<Entity.Builder> postProcessedEntityBuilders =
+        this.responsePostProcessor.transform(executionContext, entityBuilders);
+    assertEquals(2, postProcessedEntityBuilders.size());
+
+    Entity.Builder firstEntityBuilder = postProcessedEntityBuilders.get(0);
+    assertEquals(1, firstEntityBuilder.getMetricSeriesCount());
+    assertEquals(
+        MetricSeries.newBuilder()
+            .addValue(Interval.newBuilder().setValue(Value.newBuilder().setLong(2).build()).build())
+            .build(),
+        firstEntityBuilder.getMetricSeriesMap().get("API.duration"));
+
+    Entity.Builder secondEntityBuilder = postProcessedEntityBuilders.get(1);
+    assertEquals(1, secondEntityBuilder.getMetricSeriesCount());
+    assertEquals(
+        MetricSeries.getDefaultInstance(),
+        secondEntityBuilder.getMetricSeriesMap().get("API.duration"));
+  }
+
+  private Expression createAttributeExpression(String attributeKey) {
+    return Expression.newBuilder()
+        .setColumnIdentifier(ColumnIdentifier.newBuilder().setAlias(attributeKey).build())
+        .build();
+  }
+
+  private Expression createAggregateExpression(String attributeKey) {
+    return Expression.newBuilder()
+        .setFunction(FunctionExpression.newBuilder().setAlias(attributeKey).build())
+        .build();
+  }
+
+  private TimeAggregation createTimeAggregation(String attributeKey) {
+    return TimeAggregation.newBuilder()
+        .setAggregation(
+            Expression.newBuilder()
+                .setFunction(FunctionExpression.newBuilder().setAlias(attributeKey).build()))
+        .build();
+  }
+}


### PR DESCRIPTION
## Description
Entities are requested with various selections, metrics and time series data. There can be cases when a selection(or metric or time series) requested does not exist on the Entity

Instead of returning no data at all for the selections, add a default value for the missing selection. Because, you should always return what you requested for, be it a valid value or a missing value

Specifically, needed for https://github.com/hypertrace/gateway-service/pull/53 and https://github.com/hypertrace/gateway-service/issues/54, because time agnostic APIs might not have attributes, metrics or time series data in the requested time range

### Testing
Tested end to end by running services locally, and unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
