### PR TITLE
Fix align both metricseries timestamps and baseline series timestamps

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/baseline/BaselineServiceImpl.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/baseline/BaselineServiceImpl.java
@@ -83,19 +83,17 @@ public class BaselineServiceImpl implements BaselineService {
           getPeriod(originalRequest.getStartTimeMillis(), originalRequest.getEndTimeMillis());
       long periodSecs = getPeriodInSecs(aggTimePeriod);
       long alignedStartTime =
-              QueryExpressionUtil.alignToPeriodBoundary(
-                      originalRequest.getStartTimeMillis(), periodSecs, true);
+          QueryExpressionUtil.alignToPeriodBoundary(
+              originalRequest.getStartTimeMillis(), periodSecs, true);
       long alignedEndTime =
-              QueryExpressionUtil.alignToPeriodBoundary(
-                      originalRequest.getEndTimeMillis(), periodSecs, false);
+          QueryExpressionUtil.alignToPeriodBoundary(
+              originalRequest.getEndTimeMillis(), periodSecs, false);
 
-      List<TimeAggregation> timeAggregations = getTimeAggregationsForAggregateExpr(originalRequest,
-              alignedStartTime, alignedEndTime);
+      List<TimeAggregation> timeAggregations =
+          getTimeAggregationsForAggregateExpr(originalRequest, alignedStartTime, alignedEndTime);
       updateAliasMap(requestContext, timeAggregations);
       // Take more data to calculate baseline and standard deviation.
-      long seriesStartTime =
-          getUpdatedStartTime(
-                  alignedStartTime, alignedEndTime);
+      long seriesStartTime = getUpdatedStartTime(alignedStartTime, alignedEndTime);
       long seriesEndTime = alignedStartTime;
       List<String> entityIdAttributes =
           AttributeMetadataUtil.getIdAttributeIds(
@@ -131,15 +129,14 @@ public class BaselineServiceImpl implements BaselineService {
           getTimeSeriesPeriod(originalRequest.getBaselineMetricSeriesRequestList());
       long periodSecs = getPeriodInSecs(timeSeriesPeriod);
       long alignedStartTime =
-              QueryExpressionUtil.alignToPeriodBoundary(
-                      originalRequest.getStartTimeMillis(), periodSecs, true);
+          QueryExpressionUtil.alignToPeriodBoundary(
+              originalRequest.getStartTimeMillis(), periodSecs, true);
       long alignedEndTime =
-              QueryExpressionUtil.alignToPeriodBoundary(
-                      originalRequest.getEndTimeMillis(), periodSecs, false);
+          QueryExpressionUtil.alignToPeriodBoundary(
+              originalRequest.getEndTimeMillis(), periodSecs, false);
       List<TimeAggregation> timeAggregations =
           getTimeAggregationsForTimeSeriesExpr(originalRequest);
-      long seriesStartTime =
-          getUpdatedStartTime(alignedStartTime, alignedEndTime);
+      long seriesStartTime = getUpdatedStartTime(alignedStartTime, alignedEndTime);
       long seriesEndTime = alignedStartTime;
       List<String> entityIdAttributes =
           AttributeMetadataUtil.getIdAttributeIds(
@@ -168,10 +165,7 @@ public class BaselineServiceImpl implements BaselineService {
               alignedEndTime);
       baselineEntityTimeSeriesMap =
           getEntitiesMapFromTimeSeriesResponse(
-              timeSeriesEntitiesResponse,
-              alignedStartTime,
-              alignedEndTime,
-              periodSecs);
+              timeSeriesEntitiesResponse, alignedStartTime, alignedEndTime, periodSecs);
     }
 
     return mergeEntities(baselineEntityAggregatedMetricsMap, baselineEntityTimeSeriesMap);
@@ -337,13 +331,12 @@ public class BaselineServiceImpl implements BaselineService {
   }
 
   private List<TimeAggregation> getTimeAggregationsForAggregateExpr(
-          BaselineEntitiesRequest originalRequest, long alignedStartTime, long alignedEndTime) {
+      BaselineEntitiesRequest originalRequest, long alignedStartTime, long alignedEndTime) {
     List<FunctionExpression> aggregateList = originalRequest.getBaselineAggregateRequestList();
     List<TimeAggregation> timeAggregationList = new ArrayList<>();
     for (FunctionExpression function : aggregateList) {
       TimeAggregation timeAggregation =
-          getAggregationFunction(
-              function, alignedStartTime, alignedEndTime);
+          getAggregationFunction(function, alignedStartTime, alignedEndTime);
       timeAggregationList.add(timeAggregation);
     }
     return timeAggregationList;


### PR DESCRIPTION
## Description
In time series data timestamps of metric series and baseline metric series are not matching, baseline startTime and endTime also aligned with nearest period boundary to match timestamps.
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Local testing done and its working.

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
