### PR TITLE
optimize metric aggregations order by

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionContext.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionContext.java
@@ -206,12 +206,16 @@ public class ExecutionContext {
     pendingSelectionSources.remove(source);
   }
 
-  public void removePendingMetricAggregationSources(String source) {
+  public void removePendingMetricAggregationSource(String source) {
     pendingMetricAggregationSources.remove(source);
   }
 
   public void removePendingSelectionSourceForOrderBy(String source) {
     pendingSelectionSourcesForOrderBy.remove(source);
+  }
+
+  public void removePendingMetricAggregationSourceForOrderBy(String source) {
+    pendingMetricAggregationSourcesForOrderBy.remove(source);
   }
 
   public Map<String, List<Expression>> getSourceToFilterExpressionMap() {

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilder.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilder.java
@@ -197,7 +197,7 @@ public class ExecutionTreeBuilder {
           new SelectionNode.Builder(rootNode)
               .setAggMetricSelectionSources(metricSourcesForOrderBy)
               .build();
-      metricSourcesForOrderBy.forEach(executionContext::removePendingMetricAggregationSources);
+      metricSourcesForOrderBy.forEach(executionContext::removePendingMetricAggregationSource);
     }
 
     // Try adding SortAndPaginateNode

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionContextBuilderVisitor.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionContextBuilderVisitor.java
@@ -58,6 +58,13 @@ public class ExecutionContextBuilderVisitor implements Visitor<Void> {
     executionContext.removePendingSelectionSource(source);
     // TODO: Currently, assumes that the order by attribute is also present in the selection set
     executionContext.removePendingSelectionSourceForOrderBy(source);
+    // TODO: Remove redundant attributes for metric aggregation source for order by
+    // The current metric aggregation source is only QS
+
+    // The order by on metric aggregations will also be added in the selections list of
+    // DataFetcherNode, so that the order by metric aggregations can be fetched before
+    // and only the required data set is paginated
+    executionContext.removePendingMetricAggregationSourceForOrderBy(source);
 
     // set of attributes which were fetched from the source
     Map<String, Set<String>> sourceToSelectionAttributeMap =


### PR DESCRIPTION
## Description
Keeping this as a draft PR, since none of the use cases need this optimization yet. The optimization comes into play when there is a filter on an attribute in EDS and order by QS aggregations

Pushes the metric aggregation order by down as a selection, so that only required data is fetched for paginating in memory, instead of fetching all the data for pagination

### Testing
Tested end to end

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules