### PR TITLE
fix(entities): selections on eds, and filters/order by on qs

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/FilterOptimizingVisitor.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/FilterOptimizingVisitor.java
@@ -110,12 +110,22 @@ public class FilterOptimizingVisitor implements Visitor<QueryNode> {
 
   @Override
   public QueryNode visit(SelectionNode selectionNode) {
-    return selectionNode;
+    QueryNode childNode = selectionNode.getChildNode().acceptVisitor(this);
+    return new SelectionNode.Builder(childNode)
+        .setTimeSeriesSelectionSources(selectionNode.getTimeSeriesSelectionSources())
+        .setAggMetricSelectionSources(selectionNode.getAggMetricSelectionSources())
+        .setAttrSelectionSources(selectionNode.getAttrSelectionSources())
+        .build();
   }
 
   @Override
   public QueryNode visit(SortAndPaginateNode sortAndPaginateNode) {
-    return sortAndPaginateNode;
+    QueryNode childNode = sortAndPaginateNode.getChildNode().acceptVisitor(this);
+    return new SortAndPaginateNode(
+        childNode,
+        sortAndPaginateNode.getLimit(),
+        sortAndPaginateNode.getOffset(),
+        sortAndPaginateNode.getOrderByExpressionList());
   }
 
   private Map<String, QueryNode> mergeQueryNodesBySource(
@@ -179,6 +189,8 @@ public class FilterOptimizingVisitor implements Visitor<QueryNode> {
 
   @Override
   public QueryNode visit(PaginateOnlyNode paginateOnlyNode) {
-    return paginateOnlyNode;
+    QueryNode childNode = paginateOnlyNode.getChildNode().acceptVisitor(this);
+    return new PaginateOnlyNode(
+        childNode, paginateOnlyNode.getLimit(), paginateOnlyNode.getOffset());
   }
 }

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/FilterOptimizingVisitorTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/FilterOptimizingVisitorTest.java
@@ -11,6 +11,8 @@ import org.hypertrace.gateway.service.entity.query.AndNode;
 import org.hypertrace.gateway.service.entity.query.DataFetcherNode;
 import org.hypertrace.gateway.service.entity.query.PaginateOnlyNode;
 import org.hypertrace.gateway.service.entity.query.QueryNode;
+import org.hypertrace.gateway.service.entity.query.SelectionNode;
+import org.hypertrace.gateway.service.entity.query.SortAndPaginateNode;
 import org.hypertrace.gateway.service.v1.common.Filter;
 import org.hypertrace.gateway.service.v1.common.Operator;
 import org.hypertrace.gateway.service.v1.common.OrderByExpression;
@@ -18,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public class FilterOptimizingVisitorTest {
   @Test
@@ -29,6 +32,49 @@ public class FilterOptimizingVisitorTest {
     assertEquals(paginateOnlyNode.getChildNode(), visitedPaginatedOnlyNode.getChildNode());
     assertEquals(paginateOnlyNode.getLimit(), visitedPaginatedOnlyNode.getLimit());
     assertEquals(paginateOnlyNode.getOffset(), visitedPaginatedOnlyNode.getOffset());
+  }
+
+  @Test
+  public void testSelectionNode() {
+    DataFetcherNode dataFetcherNode = new DataFetcherNode("QS", Filter.getDefaultInstance());
+    Set<String> attrSelectionSources = Set.of("QS", "EDS");
+    Set<String> aggregationSources = Set.of("QS");
+    Set<String> timeAggregationSources = Set.of("source1", "source2");
+    SelectionNode selectionNode =
+        new SelectionNode.Builder(dataFetcherNode)
+            .setAttrSelectionSources(attrSelectionSources)
+            .setAggMetricSelectionSources(aggregationSources)
+            .setTimeSeriesSelectionSources(timeAggregationSources)
+            .build();
+    FilterOptimizingVisitor filterOptimizingVisitor = new FilterOptimizingVisitor();
+    SelectionNode visitedSelectionNode =
+        (SelectionNode) filterOptimizingVisitor.visit(selectionNode);
+    assertEquals(selectionNode.getChildNode(), visitedSelectionNode.getChildNode());
+    assertEquals(
+        selectionNode.getAttrSelectionSources(), visitedSelectionNode.getAttrSelectionSources());
+    assertEquals(
+        selectionNode.getAggMetricSelectionSources(),
+        visitedSelectionNode.getAggMetricSelectionSources());
+    assertEquals(
+        selectionNode.getTimeSeriesSelectionSources(),
+        visitedSelectionNode.getTimeSeriesSelectionSources());
+  }
+
+  @Test
+  public void testSortAndPaginateNode() {
+    OrderByExpression orderByExpression = buildOrderByExpression("api1");
+
+    DataFetcherNode dataFetcherNode = new DataFetcherNode("QS", Filter.getDefaultInstance());
+    SortAndPaginateNode sortAndPaginateNode =
+        new SortAndPaginateNode(dataFetcherNode, 10, 20, List.of(orderByExpression));
+
+    FilterOptimizingVisitor filterOptimizingVisitor = new FilterOptimizingVisitor();
+    SortAndPaginateNode visitedSortAndPaginateNode =
+        (SortAndPaginateNode) filterOptimizingVisitor.visit(sortAndPaginateNode);
+    assertEquals(sortAndPaginateNode.getChildNode(), visitedSortAndPaginateNode.getChildNode());
+    assertEquals(10, visitedSortAndPaginateNode.getLimit());
+    assertEquals(20, visitedSortAndPaginateNode.getOffset());
+    assertEquals(List.of(orderByExpression), visitedSortAndPaginateNode.getOrderByExpressionList());
   }
 
   @Test

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/FilterOptimizingVisitorTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/FilterOptimizingVisitorTest.java
@@ -22,9 +22,13 @@ import java.util.List;
 public class FilterOptimizingVisitorTest {
   @Test
   public void testPaginateOnlyNode() {
-    PaginateOnlyNode paginateOnlyNode = mock(PaginateOnlyNode.class);
+    DataFetcherNode dataFetcherNode = new DataFetcherNode("QS", Filter.getDefaultInstance());
+    PaginateOnlyNode paginateOnlyNode = new PaginateOnlyNode(dataFetcherNode, 10, 10);
     FilterOptimizingVisitor filterOptimizingVisitor = new FilterOptimizingVisitor();
-    assertEquals(paginateOnlyNode, filterOptimizingVisitor.visit(paginateOnlyNode));
+    PaginateOnlyNode visitedPaginatedOnlyNode = (PaginateOnlyNode) filterOptimizingVisitor.visit(paginateOnlyNode);
+    assertEquals(paginateOnlyNode.getChildNode(), visitedPaginatedOnlyNode.getChildNode());
+    assertEquals(paginateOnlyNode.getLimit(), visitedPaginatedOnlyNode.getLimit());
+    assertEquals(paginateOnlyNode.getOffset(), visitedPaginatedOnlyNode.getOffset());
   }
 
   @Test


### PR DESCRIPTION
## Description
Entities request was failing if the selections were both on EDS and QS, but filters and order by are on QS. The reason for failure being the AndNode/OrNode in `FilterOptimizingVisitor`assumes that the children can only be DataFetcherNode and nothing else, but since we were pushing pagination down to QS, it also had a `PaginateOnlyNode` on top of `DataFetcherNode`

### Testing
Added unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules