### PR TITLE
fix: when a list is returned as null, convert it to empty

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/converters/StringToAttributeKindConverter.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/converters/StringToAttributeKindConverter.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.hypertrace.core.attribute.service.v1.AttributeKind;
 import org.hypertrace.gateway.service.v1.common.Value;
@@ -89,7 +91,8 @@ public class StringToAttributeKindConverter extends ToAttributeKindConverter<Str
 
     // Check if the string is already in a list format.
     try {
-      return objectMapper.readValue(jsonString, LIST_TYPE_REFERENCE);
+      return Optional.ofNullable(objectMapper.readValue(jsonString, LIST_TYPE_REFERENCE))
+          .orElse(Collections.emptyList());
     } catch (JsonProcessingException e) {
       // If not, it might be a single string, so return a list with one element.
       return List.of(jsonString);

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/converter/StringToAttributeKindConverterTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/converter/StringToAttributeKindConverterTest.java
@@ -59,4 +59,16 @@ public class StringToAttributeKindConverterTest {
         ).getStringArrayList()
     );
   }
+
+  @Test
+  public void test_nullStringToArrayReturnsEmptyList() {
+    StringToAttributeKindConverter converter = StringToAttributeKindConverter.INSTANCE;
+    assertEquals(List.of(),
+        converter.doConvert(
+            "null",
+            AttributeKind.TYPE_STRING_ARRAY,
+            Value.newBuilder()
+        ).getStringArrayList());
+  }
+
 }


### PR DESCRIPTION
## Description
This changes the behavior when querying for a string array that is returned as null from query service. Currently, such a case causes a NPE and fails the query as proto does not support setting nulls. With this change, we now convert nulls into empty lists, which is the same behavior we have for the empty string and seems overall consistent.

### Testing
Verified this with an e2e query, also added unit test.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
