### PR TITLE
Aligning time not required aggregationData

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/baseline/BaselineServiceImpl.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/baseline/BaselineServiceImpl.java
@@ -82,19 +82,15 @@ public class BaselineServiceImpl implements BaselineService {
       Period aggTimePeriod =
           getPeriod(originalRequest.getStartTimeMillis(), originalRequest.getEndTimeMillis());
       long periodSecs = getPeriodInSecs(aggTimePeriod);
-      long alignedStartTime =
-          QueryExpressionUtil.alignToPeriodBoundary(
-              originalRequest.getStartTimeMillis(), periodSecs, true);
-      long alignedEndTime =
-          QueryExpressionUtil.alignToPeriodBoundary(
-              originalRequest.getEndTimeMillis(), periodSecs, false);
+      long aggStartTime = originalRequest.getStartTimeMillis();
+      long aggEndTime = originalRequest.getEndTimeMillis();
 
       List<TimeAggregation> timeAggregations =
-          getTimeAggregationsForAggregateExpr(originalRequest, alignedStartTime, alignedEndTime);
+          getTimeAggregationsForAggregateExpr(originalRequest, aggStartTime, aggEndTime);
       updateAliasMap(requestContext, timeAggregations);
       // Take more data to calculate baseline and standard deviation.
-      long seriesStartTime = getUpdatedStartTime(alignedStartTime, alignedEndTime);
-      long seriesEndTime = alignedStartTime;
+      long seriesStartTime = getUpdatedStartTime(aggStartTime, aggEndTime);
+      long seriesEndTime = aggStartTime;
       List<String> entityIdAttributes =
           AttributeMetadataUtil.getIdAttributeIds(
               attributeMetadataProvider,
@@ -118,8 +114,8 @@ public class BaselineServiceImpl implements BaselineService {
               requestContext,
               entityIdAttributes.size(),
               originalRequest.getEntityType(),
-              alignedStartTime,
-              alignedEndTime);
+              aggStartTime,
+              aggEndTime);
       baselineEntityAggregatedMetricsMap = getEntitiesMapFromAggResponse(aggEntitiesResponse);
     }
 

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/baseline/BaselineServiceImplTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/baseline/BaselineServiceImplTest.java
@@ -68,7 +68,7 @@ public class BaselineServiceImplTest {
     Mockito.when(
             baselineServiceQueryExecutor.executeQuery(
                 Mockito.anyMap(), Mockito.any(QueryRequest.class)))
-        .thenReturn(getResultSet().iterator());
+        .thenReturn(getResultSet("duration_ts").iterator());
     when(entityIdColumnsConfigs.getIdKey("SERVICE")).thenReturn(Optional.of("id"));
 
     Map<String, AttributeMetadata> attributeMap = new HashMap<>();
@@ -106,12 +106,12 @@ public class BaselineServiceImplTest {
             .addEntityIds("entity-1")
             .addBaselineAggregateRequest(
                 getFunctionExpressionForAvgRate(
-                    FunctionType.AVGRATE, "SERVICE.duration", "duration_ts"))
+                    FunctionType.AVGRATE, "SERVICE.numCalls", "numCalls"))
             .build();
 
     // Mock section
     AttributeMetadata attributeMetadata =
-        AttributeMetadata.newBuilder().setFqn("Service.Latency").setId("Service.StartTime").build();
+        AttributeMetadata.newBuilder().setFqn("Service.numCalls").setId("Service.Id").build();
     Mockito.when(
             attributeMetadataProvider.getAttributeMetadata(
                 Mockito.any(RequestContext.class), Mockito.anyString(), Mockito.anyString()))
@@ -119,13 +119,13 @@ public class BaselineServiceImplTest {
     Mockito.when(
             baselineServiceQueryExecutor.executeQuery(
                 Mockito.anyMap(), Mockito.any(QueryRequest.class)))
-        .thenReturn(getResultSet().iterator());
+        .thenReturn(getResultSet("numCalls").iterator());
     when(entityIdColumnsConfigs.getIdKey("SERVICE")).thenReturn(Optional.of("id"));
-    // Attribute Metadata map contains mapping between Attributes and ID to query data. 
+    // Attribute Metadata map contains mapping between Attributes and ID to query data.
     Map<String, AttributeMetadata> attributeMap = new HashMap<>();
     attributeMap.put(
-        "SERVICE.duration",
-        AttributeMetadata.newBuilder().setFqn("Service.Latency").setId("Service.Id").build());
+        "SERVICE.numCalls",
+        AttributeMetadata.newBuilder().setFqn("Service.numCalls").setId("Service.Id").build());
     Mockito.when(
             attributeMetadataProvider.getAttributesMetadata(
                 Mockito.any(RequestContext.class), Mockito.anyString()))
@@ -145,7 +145,7 @@ public class BaselineServiceImplTest {
     BaselineEntity baselineEntity = baselineResponse.getBaselineEntityList().get(0);
     // verify the baseline for AVG RATE (medianValue/60)
     Assertions.assertEquals(1.0,
-        baselineEntity.getBaselineAggregateMetricMap().get("duration_ts").getValue().getDouble());
+        baselineEntity.getBaselineAggregateMetricMap().get("numCalls").getValue().getDouble());
   }
 
   @Test
@@ -168,7 +168,7 @@ public class BaselineServiceImplTest {
     Mockito.when(
             baselineServiceQueryExecutor.executeQuery(
                 Mockito.anyMap(), Mockito.any(QueryRequest.class)))
-        .thenReturn(getResultSet().iterator());
+        .thenReturn(getResultSet("duration_ts").iterator());
     Map<String, AttributeMetadata> attributeMap = new HashMap<>();
     AttributeMetadata attribute =
         AttributeMetadata.newBuilder().setFqn("Service.Latency").setId("Service.Id").build();
@@ -234,12 +234,12 @@ public class BaselineServiceImplTest {
         .build();
   }
 
-  public List<ResultSetChunk> getResultSet() {
+  public List<ResultSetChunk> getResultSet(String alias) {
     long time = Instant.parse("2020-11-14T18:40:51.902Z").toEpochMilli();
 
     return List.of(
         getResultSetChunk(
-            List.of("SERVICE.id", "dateTimeConvert", "duration_ts"),
+            List.of("SERVICE.id", "dateTimeConvert", alias),
             new String[][] {
               {"entity-1", String.valueOf(time), "20.0"},
               {"entity-1", String.valueOf(time - 60000), "40.0"},


### PR DESCRIPTION
## Description
Aligning timestamp not required for Aggregation data, its only needed for time series data. 

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
