### PR TITLE
chore(entities-api): flag to fetch total entitiess

### DIFF
--- a/gateway-service-api/src/main/proto/org/hypertrace/gateway/service/v1/entities.proto
+++ b/gateway-service-api/src/main/proto/org/hypertrace/gateway/service/v1/entities.proto
@@ -47,6 +47,7 @@ message EntitiesRequest {
   int32 offset = 21;
   bool include_non_live_entities = 22;
   string space_id = 23;
+  bool fetchTotal = 24;
 }
 
 message EntitiesResponse {

--- a/gateway-service-api/src/main/proto/org/hypertrace/gateway/service/v1/entities.proto
+++ b/gateway-service-api/src/main/proto/org/hypertrace/gateway/service/v1/entities.proto
@@ -47,7 +47,7 @@ message EntitiesRequest {
   int32 offset = 21;
   bool include_non_live_entities = 22;
   string space_id = 23;
-  bool fetchTotal = 24;
+  bool fetch_total = 24;
 }
 
 message EntitiesResponse {


### PR DESCRIPTION
## Description
Added a flag to fetch total number of entities. If the flag is set, the total number of entities will be fetched from the data store, else ignored

The actual implementation will come as a separate PR https://github.com/hypertrace/gateway-service/pull/76 to make the change backward compatible, because the current clients assume that the total number of entities will always be fetched. 

Hence, the clients need to change first using the latest Gateway Service API

### Testing
No testing required, since it's just a proto API change

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules