### PR TITLE
perf(entities): fetch total entities, only if requested

### DIFF
--- a/gateway-service-api/src/main/proto/org/hypertrace/gateway/service/v1/entities.proto
+++ b/gateway-service-api/src/main/proto/org/hypertrace/gateway/service/v1/entities.proto
@@ -47,6 +47,7 @@ message EntitiesRequest {
   int32 offset = 21;
   bool include_non_live_entities = 22;
   string space_id = 23;
+  bool fetchTotal = 24;
 }
 
 message EntitiesResponse {

--- a/gateway-service-api/src/main/proto/org/hypertrace/gateway/service/v1/entities.proto
+++ b/gateway-service-api/src/main/proto/org/hypertrace/gateway/service/v1/entities.proto
@@ -47,7 +47,7 @@ message EntitiesRequest {
   int32 offset = 21;
   bool include_non_live_entities = 22;
   string space_id = 23;
-  bool fetchTotal = 24;
+  bool fetch_total = 24;
 }
 
 message EntitiesResponse {

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/DataFetcherNode.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/DataFetcherNode.java
@@ -21,12 +21,12 @@ public class DataFetcherNode implements QueryNode {
   private Integer offset;
   private List<OrderByExpression> orderByExpressionList = Collections.emptyList();
 
-  private final boolean isPaginated;
+  private final boolean canFetchTotal;
 
   public DataFetcherNode(String source, Filter filter) {
     this.source = source;
     this.filter = filter;
-    this.isPaginated = false;
+    this.canFetchTotal = false; // total would be computed in memory
   }
 
   public DataFetcherNode(
@@ -34,13 +34,18 @@ public class DataFetcherNode implements QueryNode {
       Filter filter,
       Integer limit,
       Integer offset,
-      List<OrderByExpression> orderByExpressionList) {
+      List<OrderByExpression> orderByExpressionList,
+      boolean canFetchTotal) {
     this.source = source;
     this.filter = filter;
     this.limit = limit;
     this.offset = offset;
     this.orderByExpressionList = orderByExpressionList;
-    this.isPaginated = limit != null && offset != null;
+
+    boolean isPaginated = limit != null && offset != null;
+    // should only fetch total, if the pagination is pushed down to the data store
+    // and total has been requested by the client
+    this.canFetchTotal = isPaginated && canFetchTotal;
   }
 
   public String getSource() {
@@ -63,8 +68,8 @@ public class DataFetcherNode implements QueryNode {
     return orderByExpressionList;
   }
 
-  public boolean isPaginated() {
-    return isPaginated;
+  public boolean canFetchTotal() {
+    return canFetchTotal;
   }
 
   @Override
@@ -80,7 +85,7 @@ public class DataFetcherNode implements QueryNode {
         ", limit=" + limit +
         ", offset=" + offset +
         ", orderByExpressionList=" + orderByExpressionList +
-        ", isPaginated=" + isPaginated +
+        ", fetchTotal=" + canFetchTotal +
         '}';
   }
 }

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilder.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilder.java
@@ -85,7 +85,8 @@ public class ExecutionTreeBuilder {
                 entitiesRequest.getFilter(),
                 entitiesRequest.getLimit(),
                 entitiesRequest.getOffset(),
-                entitiesRequest.getOrderByList());
+                entitiesRequest.getOrderByList(),
+                entitiesRequest.getFetchTotal());
         executionContext.setSortAndPaginationNodeAdded(true);
       }
 
@@ -175,12 +176,16 @@ public class ExecutionTreeBuilder {
   }
 
   private QueryNode buildExecutionTreeForEdsFilterAndSelection() {
-    Filter filter = executionContext.getEntitiesRequest().getFilter();
-    int selectionLimit = executionContext.getEntitiesRequest().getLimit();
-    int selectionOffset = executionContext.getEntitiesRequest().getOffset();
-    List<OrderByExpression> orderBys = executionContext.getEntitiesRequest().getOrderByList();
+    EntitiesRequest entitiesRequest = executionContext.getEntitiesRequest();
+    Filter filter = entitiesRequest.getFilter();
+    int selectionLimit = entitiesRequest.getLimit();
+    int selectionOffset = entitiesRequest.getOffset();
+    List<OrderByExpression> orderBys = entitiesRequest.getOrderByList();
+    boolean canFetchTotal = entitiesRequest.getFetchTotal();
 
-    QueryNode rootNode = new DataFetcherNode(EDS.name(), filter, selectionLimit, selectionOffset, orderBys);
+    QueryNode rootNode =
+        new DataFetcherNode(
+            EDS.name(), filter, selectionLimit, selectionOffset, orderBys, canFetchTotal);
     executionContext.setSortAndPaginationNodeAdded(true);
     return rootNode;
   }
@@ -327,6 +332,7 @@ public class ExecutionTreeBuilder {
     int selectionLimit = entitiesRequest.getLimit();
     int selectionOffset = entitiesRequest.getOffset();
     List<OrderByExpression> orderBys = entitiesRequest.getOrderByList();
+    boolean canFetchTotal = entitiesRequest.getFetchTotal();
 
     // query-service/Pinot does not support offset when group by is specified. Since we will be
     // grouping by at least the entity id, we will compute the non zero pagination ourselves. This
@@ -338,7 +344,8 @@ public class ExecutionTreeBuilder {
       selectionOffset = 0;
     }
 
-    return new DataFetcherNode(QS.name(), filter, selectionLimit, selectionOffset, orderBys);
+    return new DataFetcherNode(
+        QS.name(), filter, selectionLimit, selectionOffset, orderBys, canFetchTotal);
   }
 
   private QueryNode createPaginateOnlyNode(QueryNode queryNode, EntitiesRequest entitiesRequest) {

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitor.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitor.java
@@ -172,9 +172,9 @@ public class ExecutionVisitor implements Visitor<EntityResponse> {
     EntitiesRequest request = requestBuilder.build();
     IEntityFetcher entityFetcher = queryHandlerRegistry.getEntityFetcher(source);
 
-    // if the data fetcher node is fetching paginated records, the total number of entities has to
-    // be fetched separately
-    if (dataFetcherNode.isPaginated()) {
+    // if the data fetcher node is fetching paginated records and the client has requested for
+    // total, the total number of entities has to be fetched separately
+    if (dataFetcherNode.canFetchTotal()) {
       EntitiesRequest totalEntitiesRequest =
           EntitiesRequest.newBuilder(executionContext.getEntitiesRequest())
               .clearSelection()

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/FilterOptimizingVisitor.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/FilterOptimizingVisitor.java
@@ -174,7 +174,8 @@ public class FilterOptimizingVisitor implements Visitor<QueryNode> {
                               filter,
                               dataFetcherNode.getLimit(),
                               dataFetcherNode.getOffset(),
-                              dataFetcherNode.getOrderByExpressionList());
+                              dataFetcherNode.getOrderByExpressionList(),
+                              dataFetcherNode.canFetchTotal());
                     } else {
                       return new NoOpNode();
                     }

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/FilterOptimizingVisitorTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/FilterOptimizingVisitorTest.java
@@ -85,9 +85,9 @@ public class FilterOptimizingVisitorTest {
     int offset = 5;
     List<OrderByExpression> orderByExpressions = Collections.singletonList(buildOrderByExpression("API.id"));
     DataFetcherNode dataFetcherNode1 =
-        new DataFetcherNode("QS", filter1, limit, offset, orderByExpressions);
+        new DataFetcherNode("QS", filter1, limit, offset, orderByExpressions, true);
     DataFetcherNode dataFetcherNode2 =
-        new DataFetcherNode("QS", filter2, limit, offset, orderByExpressions);
+        new DataFetcherNode("QS", filter2, limit, offset, orderByExpressions, true);
     AndNode andNode = new AndNode(List.of(dataFetcherNode1, dataFetcherNode2));
     QueryNode queryNode = andNode.acceptVisitor(new FilterOptimizingVisitor());
 


### PR DESCRIPTION
## Description
Total number of entities should only be fetched, if requested by the client

### Testing
Added unit test

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules