### PR TITLE
refactor: using micrometer based metrics and consistent with its names

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,6 +5,6 @@ ignore:
   SNYK-JAVA-IONETTY-1042268:
     - '*':
         reason: No replacement available
-        expires: 2021-01-31T00:00:00.000Z
+        expires: 2021-02-28T00:00:00.000Z
 
 patch: {}

--- a/gateway-service-impl/build.gradle.kts
+++ b/gateway-service-impl/build.gradle.kts
@@ -37,10 +37,7 @@ dependencies {
   implementation("org.apache.commons:commons-lang3:3.10")
   implementation("org.apache.commons:commons-math:2.2")
   implementation("com.google.protobuf:protobuf-java-util:3.13.0")
-
-  // Metrics
-  implementation("io.dropwizard.metrics:metrics-core:4.1.9")
-
+  
   // Needed by clusters snapshots
   implementation("com.fasterxml.jackson.core:jackson-annotations:2.11.1")
   implementation("com.fasterxml.jackson.core:jackson-databind:2.11.1")


### PR DESCRIPTION
## Description
- Remove usage of deprecated methods from Platformregistry metrics library in support of using micrometer library
- Using prefix - `hypertrace` - for all metrics for consistency


### Testing
Tested locally using docker-compose (see notes below)

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
will update the existing documentation referring to metrics and dashboards - https://github.com/hypertrace/hypertrace/tree/main/kubernetes/monitoring
