### PR TITLE
fix: add support for reversing explore time series request

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,6 +5,6 @@ ignore:
   SNYK-JAVA-IONETTY-1042268:
     - '*':
         reason: No replacement available
-        expires: 2021-02-28T00:00:00.000Z
+        expires: 2021-04-30T00:00:00.000Z
 
 patch: {}

--- a/gateway-service-api/build.gradle.kts
+++ b/gateway-service-api/build.gradle.kts
@@ -17,7 +17,7 @@ protobuf {
     // the identifier, which can be referred to in the "plugins"
     // container of the "generateProtoTasks" closure.
     id("grpc_java") {
-      artifact = "io.grpc:protoc-gen-grpc-java:1.32.1"
+      artifact = "io.grpc:protoc-gen-grpc-java:1.36.0"
     }
   }
   generateProtoTasks {
@@ -42,9 +42,9 @@ sourceSets {
 }
 
 dependencies {
-  api("io.grpc:grpc-protobuf:1.33.0")
+  api("io.grpc:grpc-protobuf:1.36.0")
   api("com.google.api.grpc:proto-google-common-protos:1.18.1")
-  api("io.grpc:grpc-stub:1.33.0")
+  api("io.grpc:grpc-stub:1.36.0")
   api("javax.annotation:javax.annotation-api:1.3.2")
 
   constraints {

--- a/gateway-service-impl/build.gradle.kts
+++ b/gateway-service-impl/build.gradle.kts
@@ -11,24 +11,12 @@ tasks.test {
 dependencies {
   api(project(":gateway-service-api"))
 
-  constraints {
-    implementation("com.google.guava:guava:30.0-jre") {
-      because("Information Disclosure [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415] in com.google.guava:guava@29.0-android")
-    }
-    testRuntimeOnly("io.netty:netty-codec-http2:4.1.53.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1020439")
-    }
-    testRuntimeOnly("io.netty:netty-handler-proxy:4.1.53.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1020439s")
-    }
-  }
-
   implementation("org.hypertrace.core.query.service:query-service-client:0.5.2")
   implementation("org.hypertrace.core.attribute.service:attribute-service-client:0.9.3")
   implementation("org.hypertrace.entity.service:entity-service-client:0.5.6")
   implementation("org.hypertrace.entity.service:entity-service-api:0.5.6")
-  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.2")
-  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.19")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.4")
+  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.21")
 
   // Config
   implementation("com.typesafe:config:1.4.1")
@@ -45,5 +33,5 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
   testImplementation("org.mockito:mockito-core:3.6.28")
   testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.14.0")
-  testImplementation("io.grpc:grpc-netty:1.33.1")
+  testImplementation("io.grpc:grpc-netty:1.36.0")
 }

--- a/gateway-service/build.gradle.kts
+++ b/gateway-service/build.gradle.kts
@@ -8,10 +8,10 @@ plugins {
 dependencies {
   implementation(project(":gateway-service-impl"))
 
-  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.3.2")
-  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.18")
+  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.3.4")
+  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.21")
 
-  implementation("io.grpc:grpc-netty:1.33.1")
+  implementation("io.grpc:grpc-netty:1.36.0")
 
   // Logging
   implementation("org.slf4j:slf4j-api:1.7.30")
@@ -23,11 +23,11 @@ dependencies {
   implementation("com.typesafe:config:1.4.1")
 
   constraints {
-    runtimeOnly("io.netty:netty-codec-http2:4.1.54.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1020439")
+    runtimeOnly("io.netty:netty-codec-http2:4.1.60.Final") {
+      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1083991")
     }
-    runtimeOnly("io.netty:netty-handler-proxy:4.1.54.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1020439s")
+    runtimeOnly("io.netty:netty-handler-proxy:4.1.60.Final") {
+      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1083991")
     }
   }
 }


### PR DESCRIPTION
## Description
Add support for explicitly declaring the ordering of an explorer time series query. Previously, it was always assumed to be ascending with time.

### Testing
Added UT

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
