### PR TITLE
fix(entities): limit entities result in memory for QS

### DIFF
--- a/gateway-service-api/build.gradle.kts
+++ b/gateway-service-api/build.gradle.kts
@@ -17,7 +17,7 @@ protobuf {
     // the identifier, which can be referred to in the "plugins"
     // container of the "generateProtoTasks" closure.
     id("grpc_java") {
-      artifact = "io.grpc:protoc-gen-grpc-java:1.36.0"
+      artifact = "io.grpc:protoc-gen-grpc-java:1.36.1"
     }
   }
   generateProtoTasks {
@@ -42,9 +42,9 @@ sourceSets {
 }
 
 dependencies {
-  api("io.grpc:grpc-protobuf:1.36.0")
+  api("io.grpc:grpc-protobuf:1.36.1")
   api("com.google.api.grpc:proto-google-common-protos:1.18.1")
-  api("io.grpc:grpc-stub:1.36.0")
+  api("io.grpc:grpc-stub:1.36.1")
   api("javax.annotation:javax.annotation-api:1.3.2")
 
   constraints {

--- a/gateway-service-impl/build.gradle.kts
+++ b/gateway-service-impl/build.gradle.kts
@@ -33,5 +33,5 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
   testImplementation("org.mockito:mockito-core:3.6.28")
   testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.14.0")
-  testImplementation("io.grpc:grpc-netty:1.36.0")
+  testImplementation("io.grpc:grpc-netty:1.36.1")
 }

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilder.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilder.java
@@ -349,12 +349,9 @@ public class ExecutionTreeBuilder {
   }
 
   private QueryNode createPaginateOnlyNode(QueryNode queryNode, EntitiesRequest entitiesRequest) {
-    if (entitiesRequest.getOffset() > 0) {
-      return new PaginateOnlyNode(
-          queryNode,
-          entitiesRequest.getLimit(),
-          entitiesRequest.getOffset());
-    }
-    return queryNode;
+    return new PaginateOnlyNode(
+        queryNode,
+        entitiesRequest.getLimit(),
+        entitiesRequest.getOffset());
   }
 }

--- a/gateway-service/build.gradle.kts
+++ b/gateway-service/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.3.4")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.21")
 
-  implementation("io.grpc:grpc-netty:1.36.0")
+  implementation("io.grpc:grpc-netty:1.36.1")
 
   // Logging
   implementation("org.slf4j:slf4j-api:1.7.30")

--- a/gateway-service/src/main/resources/configs/common/application.conf
+++ b/gateway-service/src/main/resources/configs/common/application.conf
@@ -38,22 +38,9 @@ interaction.config = [
   }
 ]
 
-timestamp.config = [
-  {
-    scope = ACTOR
-    timestamp = lastActivity
-  },
-  {
-    scope = DOMAIN_EVENT
-    timestamp = timestamp
-  }
-]
+timestamp.config = []
 
 entity.idcolumn.config = [
-  {
-    scope = DOMAIN
-    key = id
-  },
   {
     scope = API
     key = id
@@ -70,10 +57,6 @@ entity.idcolumn.config = [
     scope = BACKEND
     key = id
   },
-  {
-    scope = ACTOR
-    key = id
-  }
 ]
 
 scopeFiltersConfig = [
@@ -94,75 +77,6 @@ scopeFiltersConfig = [
       }
     ]
   }
-]
-
-domainobject.config = [
-  {
-    scope = DOMAIN
-    key = id
-    primaryKey = true
-    mapping = [
-      {
-        scope = DOMAIN
-        key = id
-      }
-    ]
-  },
-  {
-    scope = API
-    key = id
-    primaryKey = true
-    mapping = [
-      {
-        scope = API
-        key = id
-      }
-    ]
-  },
-  {
-    scope = API_TRACE
-    key = apiTraceId
-    primaryKey = true
-    mapping = [
-      {
-        scope = API_TRACE
-        key = apiTraceId
-      }
-    ]
-  },
-  {
-    scope = SERVICE
-    key = id
-    primaryKey = true
-    mapping = [
-      {
-        scope = SERVICE
-        key = id
-      }
-    ]
-  },
-  {
-    scope = BACKEND
-    key = id
-    primaryKey = true
-    mapping = [
-      {
-        scope = BACKEND
-        key = id
-      }
-    ]
-  },
-  {
-    scope = ACTOR
-    key = id
-    primaryKey = true
-    mapping = [
-      {
-        scope = ACTOR
-        key = id
-      }
-    ]
-  },
 ]
 
 entity.service.log.config = {

--- a/gateway-service/src/main/resources/configs/common/application.conf
+++ b/gateway-service/src/main/resources/configs/common/application.conf
@@ -38,9 +38,22 @@ interaction.config = [
   }
 ]
 
-timestamp.config = []
+timestamp.config = [
+  {
+    scope = ACTOR
+    timestamp = lastActivity
+  },
+  {
+    scope = DOMAIN_EVENT
+    timestamp = timestamp
+  }
+]
 
 entity.idcolumn.config = [
+  {
+    scope = DOMAIN
+    key = id
+  },
   {
     scope = API
     key = id
@@ -57,6 +70,10 @@ entity.idcolumn.config = [
     scope = BACKEND
     key = id
   },
+  {
+    scope = ACTOR
+    key = id
+  }
 ]
 
 scopeFiltersConfig = [
@@ -77,6 +94,75 @@ scopeFiltersConfig = [
       }
     ]
   }
+]
+
+domainobject.config = [
+  {
+    scope = DOMAIN
+    key = id
+    primaryKey = true
+    mapping = [
+      {
+        scope = DOMAIN
+        key = id
+      }
+    ]
+  },
+  {
+    scope = API
+    key = id
+    primaryKey = true
+    mapping = [
+      {
+        scope = API
+        key = id
+      }
+    ]
+  },
+  {
+    scope = API_TRACE
+    key = apiTraceId
+    primaryKey = true
+    mapping = [
+      {
+        scope = API_TRACE
+        key = apiTraceId
+      }
+    ]
+  },
+  {
+    scope = SERVICE
+    key = id
+    primaryKey = true
+    mapping = [
+      {
+        scope = SERVICE
+        key = id
+      }
+    ]
+  },
+  {
+    scope = BACKEND
+    key = id
+    primaryKey = true
+    mapping = [
+      {
+        scope = BACKEND
+        key = id
+      }
+    ]
+  },
+  {
+    scope = ACTOR
+    key = id
+    primaryKey = true
+    mapping = [
+      {
+        scope = ACTOR
+        key = id
+      }
+    ]
+  },
 ]
 
 entity.service.log.config = {


### PR DESCRIPTION
## Description
Queries hitting QS assumed that pagination is pushed down to QS (_based on some condition_), but `QueryServiceEntityFetcher` has an inherent check which hardcodes the limit to 10K, if there are more than 1 group bys on the request

That means, even if there was a limit in the entities request, it was not honored, and all the entities were returned in the response. 

Fixed by limiting the results in memory

### Testing
Added unit tests and e2e locally

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules