### PR TITLE
fix: omit time range on time agnostic entity query

### DIFF
--- a/gateway-service-impl/build.gradle.kts
+++ b/gateway-service-impl/build.gradle.kts
@@ -31,7 +31,8 @@ dependencies {
   implementation("com.fasterxml.jackson.core:jackson-databind:2.11.1")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
-  testImplementation("org.mockito:mockito-core:3.6.28")
+  testImplementation("org.mockito:mockito-core:3.9.0")
+  testImplementation("org.mockito:mockito-inline:3.9.0")
   testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.14.0")
   testImplementation("io.grpc:grpc-netty:1.37.0")
 }

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/EntityDataServiceEntityFetcher.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/EntityDataServiceEntityFetcher.java
@@ -73,13 +73,15 @@ public class EntityDataServiceEntityFetcher implements IEntityFetcher {
                     .collect(Collectors.toList()));
 
     // add time filter for supported scope
-    EntityServiceAndGatewayServiceConverter.addBetweenTimeFilter(
-        entitiesRequest.getStartTimeMillis(),
-        entitiesRequest.getEndTimeMillis(),
-        attributeMetadataProvider,
-        entitiesRequest,
-        builder,
-        requestContext);
+    if (!entitiesRequest.getIncludeNonLiveEntities()) {
+      EntityServiceAndGatewayServiceConverter.addBetweenTimeFilter(
+          entitiesRequest.getStartTimeMillis(),
+          entitiesRequest.getEndTimeMillis(),
+          attributeMetadataProvider,
+          entitiesRequest,
+          builder,
+          requestContext);
+    }
 
     // Add all expressions in the select that are already not part of the EntityID attributes
     entitiesRequest.getSelectionList().stream()


### PR DESCRIPTION
## Description
Time range was being applied on entity service queries even if it was requested as time agnostic

### Testing
Added UTs

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
