### PR TITLE
fix(entities): request unique set of attributes across sources

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,6 +5,6 @@ ignore:
   SNYK-JAVA-IONETTY-1042268:
     - '*':
         reason: No replacement available
-        expires: 2021-04-30T00:00:00.000Z
+        expires: 2021-08-31T00:00:00.000Z
 
 patch: {}

--- a/gateway-service-impl/build.gradle.kts
+++ b/gateway-service-impl/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
   implementation("org.hypertrace.entity.service:entity-service-client:0.5.6")
   implementation("org.hypertrace.entity.service:entity-service-api:0.5.6")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.4")
-  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.23")
+  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.28")
 
   // Config
   implementation("com.typesafe:config:1.4.1")

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/util/ExpressionReader.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/util/ExpressionReader.java
@@ -42,6 +42,7 @@ public class ExpressionReader {
         break;
       case ORDERBY:
         extractColumns(columns, expression.getOrderBy().getExpression());
+        break;
       case LITERAL:
       case VALUE_NOT_SET:
         break;

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionContext.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionContext.java
@@ -1,7 +1,6 @@
 package org.hypertrace.gateway.service.entity.query;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionContext.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionContext.java
@@ -502,10 +502,4 @@ public class ExecutionContext {
         + allAttributesToSourcesMap
         + '}';
   }
-
-  public static void main(String[] args) {
-    Map<String, List<Integer>> map =
-        Map.of("a", List.of(1, 2), "b", List.of(2, 3), "c", List.of(3, 4));
-    System.out.println(Maps.filterValues(map, i -> i.stream().anyMatch(j -> j > 1)));
-  }
 }

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilder.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilder.java
@@ -73,6 +73,8 @@ public class ExecutionTreeBuilder {
     boolean areFiltersOnlyOnEds =
         ExecutionTreeUtils.areFiltersOnlyOnCurrentDataSource(executionContext, EDS.name());
     if (entitiesRequest.getIncludeNonLiveEntities() && areFiltersOnlyOnEds) {
+      ExecutionTreeUtils.removeDuplicateSelectionAttributes(executionContext, EDS.name());
+
       QueryNode rootNode = new DataFetcherNode(EDS.name(), entitiesRequest.getFilter());
       // if the filter by and order by are from the same source, pagination can be pushed down to
       // EDS
@@ -116,6 +118,8 @@ public class ExecutionTreeBuilder {
 
       return executionTree;
     }
+
+    ExecutionTreeUtils.removeDuplicateSelectionAttributes(executionContext, QS.name());
 
     QueryNode filterTree = buildFilterTree(executionContext, entitiesRequest.getFilter());
     if (LOG.isDebugEnabled()) {

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeUtils.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeUtils.java
@@ -231,23 +231,23 @@ public class ExecutionTreeUtils {
   }
 
   /**
-   * Removes duplicate selection attributes from other sources using {@param source} as the pivot
-   * source
+   * Removes duplicate selection attributes from other sources using {@param pivotSource} as the
+   * pivot source
    */
   public static void removeDuplicateSelectionAttributes(
-      ExecutionContext executionContext, String source) {
-    Map<String, Set<String>> sourceToSelectionAttributeMap =
-        Map.copyOf(executionContext.getSourceToSelectionAttributeMap());
-
-    if (!sourceToSelectionAttributeMap.containsKey(source)) {
+      ExecutionContext executionContext, String pivotSource) {
+    if (!executionContext.getSourceToSelectionAttributeMap().containsKey(pivotSource)) {
       return;
     }
 
-    Set<String> fetchedAttributes = sourceToSelectionAttributeMap.get(source);
+    Map<String, Set<String>> sourceToSelectionAttributeMap =
+        Map.copyOf(executionContext.getSourceToSelectionAttributeMap());
+
+    Set<String> fetchedAttributes = sourceToSelectionAttributeMap.get(pivotSource);
 
     for (Map.Entry<String, Set<String>> entry : sourceToSelectionAttributeMap.entrySet()) {
       String sourceKey = entry.getKey();
-      if (sourceKey.equals(source)) {
+      if (sourceKey.equals(pivotSource)) {
         continue;
       }
 

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeUtils.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeUtils.java
@@ -229,4 +229,30 @@ public class ExecutionTreeUtils {
         .reduce(Sets::intersection)
         .orElse(Collections.emptySet());
   }
+
+  /**
+   * Removes duplicate selection attributes from other sources using {@param source} as the pivot
+   * source
+   */
+  public static void removeDuplicateSelectionAttributes(
+      ExecutionContext executionContext, String source) {
+    Map<String, Set<String>> sourceToSelectionAttributeMap =
+        Map.copyOf(executionContext.getSourceToSelectionAttributeMap());
+
+    if (!sourceToSelectionAttributeMap.containsKey(source)) {
+      return;
+    }
+
+    Set<String> fetchedAttributes = sourceToSelectionAttributeMap.get(source);
+
+    for (Map.Entry<String, Set<String>> entry : sourceToSelectionAttributeMap.entrySet()) {
+      String sourceKey = entry.getKey();
+      if (sourceKey.equals(source)) {
+        continue;
+      }
+
+      Set<String> duplicateAttributes = Sets.intersection(fetchedAttributes, entry.getValue());
+      executionContext.removeSelectionAttributes(sourceKey, duplicateAttributes);
+    }
+  }
 }

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeUtilsTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeUtilsTest.java
@@ -5,7 +5,11 @@ import static org.hypertrace.core.attribute.service.v1.AttributeSource.QS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
@@ -20,9 +24,9 @@ import org.hypertrace.gateway.service.v1.common.TimeAggregation;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-public class ExecutionTreeUtilsTest {
+class ExecutionTreeUtilsTest {
   @Test
-  public void testGetSingleSourceForAllAttributes_allSourceExpressionMapKeySetsHaveOneSource() {
+  void testGetSingleSourceForAllAttributes_allSourceExpressionMapKeySetsHaveOneSource() {
     // All source expression map keysets have one source.
     ExecutionContext executionContext =
         getMockExecutionContext(
@@ -43,8 +47,7 @@ public class ExecutionTreeUtilsTest {
   }
 
   @Test
-  public void
-      testGetSingleSourceForAllAttributes_someSourceExpressionMapKeySetsHaveMultipleSources() {
+  void testGetSingleSourceForAllAttributes_someSourceExpressionMapKeySetsHaveMultipleSources() {
     ExecutionContext executionContext =
         getMockExecutionContext(
             createSourceToExpressionsMap(List.of("QS")),
@@ -64,8 +67,7 @@ public class ExecutionTreeUtilsTest {
   }
 
   @Test
-  public void
-      testGetSingleSourceForAllAttributes_someSourceExpressionMapKeySetsHaveDifferentSources() {
+  void testGetSingleSourceForAllAttributes_someSourceExpressionMapKeySetsHaveDifferentSources() {
     ExecutionContext executionContext =
         getMockExecutionContext(
             createSourceToExpressionsMap(List.of("QS")),
@@ -85,7 +87,7 @@ public class ExecutionTreeUtilsTest {
   }
 
   @Test
-  public void testGetSingleSourceForAllAttributes_someSourceExpressionMapKeySetsAreEmpty() {
+  void testGetSingleSourceForAllAttributes_someSourceExpressionMapKeySetsAreEmpty() {
     // All source expression map keysets have one source but dont have sources defined.
     ExecutionContext executionContext =
         getMockExecutionContext(
@@ -107,8 +109,7 @@ public class ExecutionTreeUtilsTest {
 
   // This scenario is not possible but for academic purposes let's test it.
   @Test
-  public void
-      testGetSingleSourceForAllAttributes_allEmptySourceExpressionMapKeySetsAndAttributes() {
+  void testGetSingleSourceForAllAttributes_allEmptySourceExpressionMapKeySetsAndAttributes() {
     ExecutionContext executionContext =
         getMockExecutionContext(
             createSourceToExpressionsMap(List.of()),
@@ -128,7 +129,7 @@ public class ExecutionTreeUtilsTest {
   }
 
   @Test
-  public void test_filtersAndOrderByFromSameSingleSourceSet() {
+  void test_filtersAndOrderByFromSameSingleSourceSet() {
     ExecutionContext executionContext = mock(ExecutionContext.class);
     // filters
     // API.id -> ["QS", "EDS"]
@@ -150,7 +151,7 @@ public class ExecutionTreeUtilsTest {
   }
 
   @Test
-  public void test_filtersAndOrderByFromSameMultipleSourceSets() {
+  void test_filtersAndOrderByFromSameMultipleSourceSets() {
     ExecutionContext executionContext = mock(ExecutionContext.class);
     // filters
     // API.id -> ["QS", "EDS"]
@@ -175,7 +176,7 @@ public class ExecutionTreeUtilsTest {
   }
 
   @Test
-  public void test_filtersAndOrderByFromEmptyOrderBy() {
+  void test_filtersAndOrderByFromEmptyOrderBy() {
     ExecutionContext executionContext = mock(ExecutionContext.class);
     // filters
     // API.id -> ["QS", "EDS"]
@@ -200,7 +201,7 @@ public class ExecutionTreeUtilsTest {
   }
 
   @Test
-  public void test_filtersAndOrderByFromEmptyFilters() {
+  void test_filtersAndOrderByFromEmptyFilters() {
     ExecutionContext executionContext = mock(ExecutionContext.class);
     // filters
     when(executionContext.getSourceToFilterAttributeMap()).thenReturn(Collections.emptyMap());
@@ -220,7 +221,7 @@ public class ExecutionTreeUtilsTest {
   }
 
   @Test
-  public void test_filtersAndOrderByFromDifferentSourceSets() {
+  void test_filtersAndOrderByFromDifferentSourceSets() {
     ExecutionContext executionContext = mock(ExecutionContext.class);
     // filters
     // API.id -> ["QS", "EDS"]
@@ -246,7 +247,7 @@ public class ExecutionTreeUtilsTest {
   @Test
   @DisplayName(
       "filters are applied on a single data source, for filters check on other data source")
-  public void test_areFiltersOnCurrentDataSource_onlyPresentOnTheCurrentDataSource() {
+  void test_areFiltersOnCurrentDataSource_onlyPresentOnTheCurrentDataSource() {
     ExecutionContext executionContext = mock(ExecutionContext.class);
     // filters
     // API.id -> ["QS", "EDS"]
@@ -263,7 +264,7 @@ public class ExecutionTreeUtilsTest {
   @Test
   @DisplayName(
       "are filters applied on a single data source, if attributes are on multiple data sources")
-  public void test_areFiltersOnCurrentDataSource_multipleSourcesForAttributes() {
+  void test_areFiltersOnCurrentDataSource_multipleSourcesForAttributes() {
     ExecutionContext executionContext = mock(ExecutionContext.class);
     // filters
     // API.id -> ["QS", "EDS"]
@@ -281,7 +282,7 @@ public class ExecutionTreeUtilsTest {
   @Test
   @DisplayName(
       "are filters applied on a single data source, if attributes are on different data sources")
-  public void test_areFiltersOnCurrentDataSource_attributesOnDifferentSources() {
+  void test_areFiltersOnCurrentDataSource_attributesOnDifferentSources() {
     ExecutionContext executionContext = mock(ExecutionContext.class);
     // filters
     // API.id -> ["QS"]
@@ -297,13 +298,44 @@ public class ExecutionTreeUtilsTest {
 
   @Test
   @DisplayName("are filters applied on a single data source, if no filters")
-  public void test_areFiltersOnCurrentDataSource_noFilters() {
+  void test_areFiltersOnCurrentDataSource_noFilters() {
     ExecutionContext executionContext = mock(ExecutionContext.class);
     // filters
     when(executionContext.getSourceToFilterAttributeMap()).thenReturn(Collections.emptyMap());
 
     assertTrue(ExecutionTreeUtils.areFiltersOnlyOnCurrentDataSource(executionContext, "QS"));
     assertTrue(ExecutionTreeUtils.areFiltersOnlyOnCurrentDataSource(executionContext, "EDS"));
+  }
+
+  @Test
+  void removeDuplicateSelectionAttributes_invalidSource() {
+    ExecutionContext executionContext = mock(ExecutionContext.class);
+    when(executionContext.getSourceToSelectionAttributeMap()).thenReturn(Collections.emptyMap());
+
+    ExecutionTreeUtils.removeDuplicateSelectionAttributes(executionContext, "INVALID");
+    verify(executionContext, never()).removeSelectionAttributes(eq("INVALID"), anySet());
+  }
+
+  @Test
+  void removeDuplicateSelectionAttributes() {
+    ExecutionContext executionContext = mock(ExecutionContext.class);
+    // API.id -> ["QS"]
+    // API.name -> ["QS", "EDS"]
+    // API.status -> ["EDS", "AS"]
+    // API.latency -> ["QS", "AS"]
+    when(executionContext.getSourceToSelectionAttributeMap())
+        .thenReturn(
+            Map.of(
+                "QS",
+                Set.of("API.id", "API.name", "API.latency"),
+                "EDS",
+                Set.of("API.name", "API.status"),
+                "AS",
+                Set.of("API.status", "API.latency")));
+
+    ExecutionTreeUtils.removeDuplicateSelectionAttributes(executionContext, "QS");
+    verify(executionContext).removeSelectionAttributes("EDS", Set.of("API.name"));
+    verify(executionContext).removeSelectionAttributes("AS", Set.of("API.latency"));
   }
 
   private ExecutionContext getMockExecutionContext(

--- a/gateway-service/build.gradle.kts
+++ b/gateway-service/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
   implementation(project(":gateway-service-impl"))
 
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.3.4")
-  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.23")
+  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.28")
 
   implementation("io.grpc:grpc-netty:1.37.0")
 


### PR DESCRIPTION
## Description
A selection attribute in entities request can be present in multiple sources. That results in non deterministic response, since the attribute is present in multiple sources, it can be returned from either of the sources, leading to non determinism in the response

The fix is to request unique set of attributes across sources, based on the pivot source. The pivot source being EDS, in case of time agnostic entities request, else the pivot source being QS by default

### Testing
Added unit tests. And, tested the UI screens manually

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
