### PR TITLE
Netty OOM fix

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/AttributeMetadataProvider.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/AttributeMetadataProvider.java
@@ -71,7 +71,7 @@ public class AttributeMetadataProvider {
                 while (attributeMetadataIterator.hasNext()) {
                   AttributeMetadata metadata = attributeMetadataIterator.next();
                   // metadata already found
-                  if(result != null) {
+                  if (result != null) {
                     continue;
                   }
                   // DON'T short-circuit the iterator.

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/AttributeMetadataProvider.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/AttributeMetadataProvider.java
@@ -67,15 +67,22 @@ public class AttributeMetadataProvider {
                             .addScopeString(scopeAndKeyPairBasedCacheKey.getDataKey().getKey())
                             .build());
 
+                AttributeMetadata result = null;
                 while (attributeMetadataIterator.hasNext()) {
                   AttributeMetadata metadata = attributeMetadataIterator.next();
+                  // metadata already found
+                  if(result != null) {
+                    continue;
+                  }
+                  // DON'T short-circuit the iterator.
+                  // Continue to iterate fully to avoid netty leak
                   if (metadata
                       .getKey()
                       .equals(scopeAndKeyPairBasedCacheKey.getDataKey().getValue())) {
-                    return metadata;
+                    result = metadata;
                   }
                 }
-                return null;
+                return result;
               }
             };
 

--- a/gateway-service/build.gradle.kts
+++ b/gateway-service/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.5.2")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.29")
 
-  implementation("io.grpc:grpc-netty-shaded:1.39.0")
+  implementation("io.grpc:grpc-netty:1.39.0")
 
   // Logging
   implementation("org.slf4j:slf4j-api:1.7.30")
@@ -22,14 +22,14 @@ dependencies {
   // Config
   implementation("com.typesafe:config:1.4.1")
 
-//  constraints {
-//    runtimeOnly("io.netty:netty-codec-http2:4.1.61.Final") {
-//      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1083991")
-//    }
-//    runtimeOnly("io.netty:netty-handler-proxy:4.1.61.Final") {
-//      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1083991")
-//    }
-//  }
+  constraints {
+    runtimeOnly("io.netty:netty-codec-http2:4.1.63.Final") {
+      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1083991")
+    }
+    runtimeOnly("io.netty:netty-handler-proxy:4.1.63.Final") {
+      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1083991")
+    }
+  }
 }
 
 application {

--- a/gateway-service/build.gradle.kts
+++ b/gateway-service/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.5.2")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.29")
 
-  implementation("io.grpc:grpc-netty:1.39.0")
+  implementation("io.grpc:grpc-netty-shaded:1.39.0")
 
   // Logging
   implementation("org.slf4j:slf4j-api:1.7.30")
@@ -22,14 +22,14 @@ dependencies {
   // Config
   implementation("com.typesafe:config:1.4.1")
 
-  constraints {
-    runtimeOnly("io.netty:netty-codec-http2:4.1.61.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1083991")
-    }
-    runtimeOnly("io.netty:netty-handler-proxy:4.1.61.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1083991")
-    }
-  }
+//  constraints {
+//    runtimeOnly("io.netty:netty-codec-http2:4.1.61.Final") {
+//      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1083991")
+//    }
+//    runtimeOnly("io.netty:netty-handler-proxy:4.1.61.Final") {
+//      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1083991")
+//    }
+//  }
 }
 
 application {


### PR DESCRIPTION
## Description
Iterating over a grpc stream partially results in memory leak both on server-side and client-side. Fixing it by completing the iteration.

### Testing
Tested manually. 

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
NA
