### PR TITLE
Parallelize trace queries

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcher.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcher.java
@@ -539,6 +539,7 @@ public class QueryServiceEntityFetcher implements IEntityFetcher {
             .addSelection(
                 createDistinctCountByColumnSelection(
                     Optional.ofNullable(entityIdAttributeIds.get(0)).orElseThrow()))
+            .setLimit(1)
             .setFilter(filterBuilder)
             .build();
 

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/executor/QueryExecutorConfig.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/executor/QueryExecutorConfig.java
@@ -1,0 +1,22 @@
+package org.hypertrace.gateway.service.executor;
+
+import com.typesafe.config.Config;
+
+public class QueryExecutorConfig {
+  private static final String CONFIG_PATH = "query.executor.config";
+  private static final String THREAD_COUNT_PATH = "thread.count";
+
+  private final int threadCount;
+
+  public static QueryExecutorConfig from(Config serviceConfig) {
+    return new QueryExecutorConfig(serviceConfig.getConfig(CONFIG_PATH).getInt(THREAD_COUNT_PATH));
+  }
+
+  QueryExecutorConfig(int threadCount) {
+    this.threadCount = threadCount;
+  }
+
+  public int getThreadCount() {
+    return threadCount;
+  }
+}

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/executor/QueryExecutorServiceFactory.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/executor/QueryExecutorServiceFactory.java
@@ -1,0 +1,16 @@
+package org.hypertrace.gateway.service.executor;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class QueryExecutorServiceFactory {
+
+  private QueryExecutorServiceFactory() {}
+
+  public static ExecutorService buildExecutorService(QueryExecutorConfig config) {
+    return Executors.newFixedThreadPool(
+        config.getThreadCount(),
+        new ThreadFactoryBuilder().setDaemon(true).setNameFormat("query-executor-%d").build());
+  }
+}

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/span/SpanService.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/span/SpanService.java
@@ -196,6 +196,7 @@ public class SpanService {
     QueryRequest queryRequest =
         createQueryWithFilter(request, context)
             .addSelection(createCountByColumnSelection(timestampAttributeId))
+            .setLimit(1)
             .build();
 
     Iterator<ResultSetChunk> resultSetChunkIterator =

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/trace/TracesService.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/trace/TracesService.java
@@ -186,8 +186,11 @@ public class TracesService {
     String firstSelectionAttributeId =
         ExpressionReader.getAttributeIdFromAttributeSelection(request.getSelection(0))
             .orElseThrow();
-    queryBuilder.addSelection(createCountByColumnSelection(firstSelectionAttributeId));
-    QueryRequest queryRequest = queryBuilder.build();
+    QueryRequest queryRequest =
+        queryBuilder
+            .addSelection(createCountByColumnSelection(firstSelectionAttributeId))
+            .setLimit(1)
+            .build();
     Iterator<ResultSetChunk> resultSetChunkIterator =
         queryServiceClient.executeQuery(queryRequest, context.getHeaders(), queryServiceReqTimeout);
     while (resultSetChunkIterator.hasNext()) {

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
@@ -706,6 +706,7 @@ public class QueryServiceEntityFetcherTests {
                       startTime,
                       endTime,
                       createStringFilter(API_DISCOVERY_STATE_ATTR, Operator.EQ, "DISCOVERED")))
+              .setLimit(1)
               .build();
 
       List<ResultSetChunk> resultSetChunks =

--- a/gateway-service-impl/src/test/resources/configs/gateway-service/application.conf
+++ b/gateway-service-impl/src/test/resources/configs/gateway-service/application.conf
@@ -17,6 +17,9 @@ attributes.service.config = {
   host = localhost
   port = 9012
 }
+query.executor.config = {
+  thread.count = 12
+}
 interaction.config = [
   {
     scope = SERVICE

--- a/gateway-service/src/main/resources/configs/common/application.conf
+++ b/gateway-service/src/main/resources/configs/common/application.conf
@@ -20,6 +20,9 @@ attributes.service.config = {
   port = 9012
   port = ${?ATTRIBUTE_SERVICE_PORT_CONFIG}
 }
+query.executor.config = {
+  thread.count = 12
+}
 interaction.config = [
   {
     scope = SERVICE


### PR DESCRIPTION
## Description
Limit total agg queries that only expect a single result. Allows better query validation on QS side.
