### PR TITLE
refactor: add limit on total queries

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcher.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcher.java
@@ -539,6 +539,7 @@ public class QueryServiceEntityFetcher implements IEntityFetcher {
             .addSelection(
                 createDistinctCountByColumnSelection(
                     Optional.ofNullable(entityIdAttributeIds.get(0)).orElseThrow()))
+            .setLimit(1)
             .setFilter(filterBuilder)
             .build();
 

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/span/SpanService.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/span/SpanService.java
@@ -196,6 +196,7 @@ public class SpanService {
     QueryRequest queryRequest =
         createQueryWithFilter(request, context)
             .addSelection(createCountByColumnSelection(timestampAttributeId))
+            .setLimit(1)
             .build();
 
     Iterator<ResultSetChunk> resultSetChunkIterator =

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/trace/TracesService.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/trace/TracesService.java
@@ -186,8 +186,11 @@ public class TracesService {
     String firstSelectionAttributeId =
         ExpressionReader.getAttributeIdFromAttributeSelection(request.getSelection(0))
             .orElseThrow();
-    queryBuilder.addSelection(createCountByColumnSelection(firstSelectionAttributeId));
-    QueryRequest queryRequest = queryBuilder.build();
+    QueryRequest queryRequest =
+        queryBuilder
+            .addSelection(createCountByColumnSelection(firstSelectionAttributeId))
+            .setLimit(1)
+            .build();
     Iterator<ResultSetChunk> resultSetChunkIterator =
         queryServiceClient.executeQuery(queryRequest, context.getHeaders(), queryServiceReqTimeout);
     while (resultSetChunkIterator.hasNext()) {

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
@@ -706,6 +706,7 @@ public class QueryServiceEntityFetcherTests {
                       startTime,
                       endTime,
                       createStringFilter(API_DISCOVERY_STATE_ATTR, Operator.EQ, "DISCOVERED")))
+              .setLimit(1)
               .build();
 
       List<ResultSetChunk> resultSetChunks =


### PR DESCRIPTION
## Description
Limit total agg queries that only expect a single result. Allows better query validation on QS side.