### PR TITLE
refactor: reduce grouped time series explorer limit

### DIFF
--- a/gateway-service-impl/build.gradle.kts
+++ b/gateway-service-impl/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
   implementation("com.google.guava:guava:30.1.1-jre")
 
   implementation("com.fasterxml.jackson.core:jackson-annotations:2.13.2")
-  implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2")
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.2")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
   testImplementation("org.mockito:mockito-core:4.3.1")

--- a/gateway-service-impl/src/test/resources/query-service-requests-and-responses/explore/grouped-time-aggregation-with-group-limit-and-the-rest.json
+++ b/gateway-service-impl/src/test/resources/query-service-requests-and-responses/explore/grouped-time-aggregation-with-group-limit-and-the-rest.json
@@ -472,7 +472,7 @@
           }
         }
       ],
-      "limit": 60000
+      "limit": 6
     },
     "response": {
       "isLastChunk": true,
@@ -2403,7 +2403,7 @@
           }
         }
       ],
-      "limit": 60000
+      "limit": 6
     },
     "response": {
       "isLastChunk": true,

--- a/gateway-service-impl/src/test/resources/query-service-requests-and-responses/explore/grouped-time-aggregation-with-group-limit.json
+++ b/gateway-service-impl/src/test/resources/query-service-requests-and-responses/explore/grouped-time-aggregation-with-group-limit.json
@@ -472,7 +472,7 @@
           }
         }
       ],
-      "limit": 60000
+      "limit": 6
     },
     "response": {
       "isLastChunk": true,

--- a/gateway-service-impl/src/test/resources/query-service-requests-and-responses/explore/time-aggregations-space-filtered.json
+++ b/gateway-service-impl/src/test/resources/query-service-requests-and-responses/explore/time-aggregations-space-filtered.json
@@ -138,7 +138,7 @@
           }
         }
       ],
-      "limit": 100000
+      "limit": 10
     },
     "response": {
       "isLastChunk": true,

--- a/gateway-service-impl/src/test/resources/query-service-requests-and-responses/explore/time-aggregations.json
+++ b/gateway-service-impl/src/test/resources/query-service-requests-and-responses/explore/time-aggregations.json
@@ -123,7 +123,7 @@
           }
         }
       ],
-      "limit": 100000
+      "limit": 10
     },
     "response": {
       "isLastChunk": true,


### PR DESCRIPTION
## Description
Fixed two issues in explorer
1. When processing results, metadata lookup was failing as it was assuming the result col name must be the attribute id, when it's actually the provided alias
2. Rather than over-limiting on TS queries, we limit to exactly the amount of returned results. I want to verify this is right, but my thinking is this is holdover from before we had separate group and row limits.

### Testing
Updated and verified UTs, tested behavior e2e
### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
