### PR TITLE
fix(explore): missing attribute kind, due to incorrect metadata map

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/ExploreRequestContext.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/ExploreRequestContext.java
@@ -26,7 +26,7 @@ public class ExploreRequestContext extends QueryRequestContext {
     this.orderByExpressions = exploreRequest.getOrderByList();
   }
 
-  ExploreRequest getExploreRequest() {
+  public ExploreRequest getExploreRequest() {
     return this.exploreRequest;
   }
 

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/entity/EntityRequestHandler.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/entity/EntityRequestHandler.java
@@ -1,6 +1,7 @@
 package org.hypertrace.gateway.service.explore.entity;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Streams;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -218,6 +219,9 @@ public class EntityRequestHandler extends RequestHandler {
     Map<String, AttributeMetadata> attributeMetadataMap =
         attributeMetadataProvider.getAttributesMetadata(
             requestContext, requestContext.getContext());
+    Map<String, AttributeMetadata> resultKeyToAttributeMetadataMap =
+        this.remapAttributeMetadataByResultName(
+            requestContext.getExploreRequest(), attributeMetadataMap);
     org.hypertrace.gateway.service.v1.common.Value gwValue;
     if (function != null) {
       // Function expression value
@@ -225,16 +229,29 @@ public class EntityRequestHandler extends RequestHandler {
           EntityServiceAndGatewayServiceConverter.convertToGatewayValueForMetricValue(
               MetricAggregationFunctionUtil.getValueTypeForFunctionType(
                   function, attributeMetadataMap),
-              attributeMetadataMap,
+              resultKeyToAttributeMetadataMap,
               metadata,
               value);
     } else {
       // Simple columnId expression value eg. groupBy columns or column selections
       gwValue =
           EntityServiceAndGatewayServiceConverter.convertToGatewayValue(
-              metadata.getColumnName(), value, attributeMetadataMap);
+              metadata.getColumnName(), value, resultKeyToAttributeMetadataMap);
     }
 
     rowBuilder.putColumns(metadata.getColumnName(), gwValue);
+  }
+
+  private Map<String, AttributeMetadata> remapAttributeMetadataByResultName(
+      ExploreRequest request, Map<String, AttributeMetadata> attributeMetadataByIdMap) {
+    return AttributeMetadataUtil.remapAttributeMetadataByResultKey(
+        Streams.concat(
+                request.getSelectionList().stream(),
+                // Add groupBy to Selection list.
+                // The expectation from the Gateway service client is that they do not add the group
+                // by expressions to the selection expressions in the request
+                request.getGroupByList().stream())
+            .collect(Collectors.toUnmodifiableList()),
+        attributeMetadataByIdMap);
   }
 }


### PR DESCRIPTION
Attribute Metadata was always missing for explore queries, leading to any value type, being displayed as string. The correct way is to convert attribute metadata map into `resultKeyToAttributeMetadataMap`, like https://github.com/hypertrace/gateway-service/blob/2255fd7c49a42a2f81fccaee1b8574feb4136cd5/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcher.java#L92