### PR TITLE
fix(explore): order by on eds attributes

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/RequestHandler.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/RequestHandler.java
@@ -99,6 +99,7 @@ public class RequestHandler implements RequestHandlerWithSorting {
     // 3. Add GroupBy
     addGroupByExpressions(builder, request);
 
+    // TODO: Push group by down to QS
     // 4. If there's no Group By, Set Limit, Offset and Order By.
     // Otherwise, specify a large limit and track actual limit, offset and order by expression list
     // so we can compute


### PR DESCRIPTION
## Description
Order by on EDS attributes in explore, had missing order by expressions set on the explore request context, which are needed later to group by, and order in memory later

### Testing
Verified the changes end to end
