### PR TITLE
fix(explore): subpath queries

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/QueryRequestContext.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/QueryRequestContext.java
@@ -3,12 +3,14 @@ package org.hypertrace.gateway.service.common;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import org.hypertrace.gateway.service.v1.common.AttributeExpression;
 import org.hypertrace.gateway.service.v1.common.FunctionExpression;
 import org.hypertrace.gateway.service.v1.common.TimeAggregation;
 
 // Hold some of request fields and mappings needed when parsing the query service response
 public class QueryRequestContext extends RequestContext {
   private final Map<String, FunctionExpression> aliasToFunctionExpressionMap = new HashMap<>();
+  private final Map<String, AttributeExpression> aliasToMapAttributeExpressionMap = new HashMap<>();
   private final long startTimeMillis;
   private final long endTimeMillis;
   private final Map<String, TimeAggregation> aliasToTimeAggregation = new HashMap<>();
@@ -30,6 +32,15 @@ public class QueryRequestContext extends RequestContext {
 
   public FunctionExpression getFunctionExpressionByAlias(String alias) {
     return aliasToFunctionExpressionMap.get(alias);
+  }
+
+  public void mapAliasToMapAttributeExpression(
+      String alias, AttributeExpression mapAttributeExpression) {
+    aliasToMapAttributeExpressionMap.put(alias, mapAttributeExpression);
+  }
+
+  public AttributeExpression getMapAttributeExpressionByAlias(String alias) {
+    return aliasToMapAttributeExpressionMap.get(alias);
   }
 
   public long getStartTimeMillis() {

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/converters/QueryAndGatewayDtoConverter.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/converters/QueryAndGatewayDtoConverter.java
@@ -572,7 +572,7 @@ public class QueryAndGatewayDtoConverter {
   }
 
   public static org.hypertrace.gateway.service.v1.common.Value
-  convertToGatewayValueForMapAttributeValue(
+      convertToGatewayValueForMapAttributeValue(
           AttributeKind attributeKind,
           Map<String, AttributeMetadata> resultKeyToAttributeMetadataMap,
           ColumnMetadata metadata,

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/converters/QueryAndGatewayDtoConverter.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/converters/QueryAndGatewayDtoConverter.java
@@ -570,4 +570,41 @@ public class QueryAndGatewayDtoConverter {
     return QueryAndGatewayDtoConverter.convertQueryValueToGatewayValue(
         queryValue, attributeMetadata);
   }
+
+  public static org.hypertrace.gateway.service.v1.common.Value
+  convertToGatewayValueForMapAttributeValue(
+          AttributeKind attributeKind,
+          Map<String, AttributeMetadata> resultKeyToAttributeMetadataMap,
+          ColumnMetadata metadata,
+          Value queryValue) {
+    String resultKey = metadata.getColumnName();
+    // if there's no override from the map, then this is regular attribute, then use the attribute
+    // map to convert the value
+    AttributeMetadata attributeMetadata;
+    if (attributeKind == null) {
+      attributeMetadata = resultKeyToAttributeMetadataMap.get(resultKey);
+    } else {
+      switch (attributeKind) {
+        case TYPE_STRING_MAP:
+          attributeMetadata =
+              AttributeMetadata.newBuilder()
+                  .setId(metadata.getColumnName())
+                  .setType(AttributeType.ATTRIBUTE)
+                  .setValueKind(AttributeKind.TYPE_STRING)
+                  .build();
+          break;
+        default:
+          LOG.error(
+              "Unrecognized map attribute kind {} for column metadata {}", attributeKind, metadata);
+          attributeMetadata = resultKeyToAttributeMetadataMap.get(resultKey);
+      }
+    }
+    LOG.debug(
+        "Converting {} from type: {} to type: {}",
+        resultKey,
+        metadata.getValueType().name(),
+        attributeMetadata.getValueKind().name());
+    return QueryAndGatewayDtoConverter.convertQueryValueToGatewayValue(
+        queryValue, attributeMetadata);
+  }
 }

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/util/AttributeMetadataUtil.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/util/AttributeMetadataUtil.java
@@ -106,16 +106,6 @@ public class AttributeMetadataUtil {
         .getId();
   }
 
-  private static AttributeMetadata getAttributeMetadata(
-      AttributeMetadataProvider attributeMetadataProvider,
-      RequestContext requestContext,
-      String scope,
-      String key) {
-    return attributeMetadataProvider
-        .getAttributeMetadata(requestContext, scope, key)
-        .orElseThrow(() -> new UnknownScopeAndKeyForAttributeException(scope, key));
-  }
-
   public static Map<String, AttributeMetadata> remapAttributeMetadataByResultKey(
       Collection<Expression> selections, Map<String, AttributeMetadata> attributeMetadataByIdMap) {
     return selections.stream()

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/TimeAggregationsRequestHandler.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/TimeAggregationsRequestHandler.java
@@ -219,10 +219,17 @@ public class TimeAggregationsRequestHandler extends RequestHandler {
           rowBuilder,
           requestContext,
           attributeMetadataProvider,
-          timeAggregation.getAggregation().getFunction());
+          timeAggregation.getAggregation().getFunction(),
+          null);
     } else { // Simple columnId Expression value eg. groupBy columns or column selections
       handleQueryServiceResponseSingleColumn(
-          queryServiceValue, metadata, rowBuilder, requestContext, attributeMetadataProvider, null);
+          queryServiceValue,
+          metadata,
+          rowBuilder,
+          requestContext,
+          attributeMetadataProvider,
+          null,
+          null);
     }
   }
 

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/explore/RequestHandlerTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/explore/RequestHandlerTest.java
@@ -1,10 +1,20 @@
 package org.hypertrace.gateway.service.explore;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.hypertrace.core.attribute.service.v1.AttributeKind;
+import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
+import org.hypertrace.core.query.service.api.ColumnMetadata;
+import org.hypertrace.core.query.service.api.QueryRequest;
 import org.hypertrace.core.query.service.client.QueryServiceClient;
 import org.hypertrace.gateway.service.common.AttributeMetadataProvider;
+import org.hypertrace.gateway.service.v1.common.AttributeExpression;
 import org.hypertrace.gateway.service.v1.common.ColumnIdentifier;
 import org.hypertrace.gateway.service.v1.common.Expression;
 import org.hypertrace.gateway.service.v1.common.FunctionExpression;
@@ -12,12 +22,12 @@ import org.hypertrace.gateway.service.v1.common.FunctionType;
 import org.hypertrace.gateway.service.v1.common.LiteralConstant;
 import org.hypertrace.gateway.service.v1.common.OrderByExpression;
 import org.hypertrace.gateway.service.v1.common.Period;
+import org.hypertrace.gateway.service.v1.common.Row;
 import org.hypertrace.gateway.service.v1.common.SortOrder;
 import org.hypertrace.gateway.service.v1.common.TimeAggregation;
 import org.hypertrace.gateway.service.v1.common.Value;
 import org.hypertrace.gateway.service.v1.common.ValueType;
 import org.hypertrace.gateway.service.v1.explore.ExploreRequest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class RequestHandlerTest {
@@ -79,9 +89,9 @@ public class RequestHandlerTest {
     List<OrderByExpression> orderByExpressions =
         requestHandler.getRequestOrderByExpressions(exploreRequest);
 
-    Assertions.assertEquals(1, orderByExpressions.size());
+    assertEquals(1, orderByExpressions.size());
     // Should switch out the alias in the OrderBy expression
-    Assertions.assertEquals(
+    assertEquals(
         OrderByExpression.newBuilder()
             .setOrder(SortOrder.ASC)
             .setExpression(
@@ -156,9 +166,9 @@ public class RequestHandlerTest {
     List<OrderByExpression> orderByExpressions =
         requestHandler.getRequestOrderByExpressions(exploreRequest);
 
-    Assertions.assertEquals(1, orderByExpressions.size());
+    assertEquals(1, orderByExpressions.size());
     // Should switch out the alias in the OrderBy expression
-    Assertions.assertEquals(
+    assertEquals(
         OrderByExpression.newBuilder()
             .setOrder(SortOrder.ASC)
             .setExpression(
@@ -233,9 +243,9 @@ public class RequestHandlerTest {
     List<OrderByExpression> orderByExpressions =
         requestHandler.getRequestOrderByExpressions(exploreRequest);
 
-    Assertions.assertEquals(1, orderByExpressions.size());
+    assertEquals(1, orderByExpressions.size());
     // Should switch out the alias in the OrderBy expression
-    Assertions.assertEquals(
+    assertEquals(
         OrderByExpression.newBuilder()
             .setOrder(SortOrder.DESC)
             .setExpression(
@@ -305,8 +315,8 @@ public class RequestHandlerTest {
     List<OrderByExpression> orderByExpressions =
         requestHandler.getRequestOrderByExpressions(exploreRequest);
 
-    Assertions.assertEquals(2, orderByExpressions.size());
-    Assertions.assertEquals(
+    assertEquals(2, orderByExpressions.size());
+    assertEquals(
         OrderByExpression.newBuilder()
             .setOrder(SortOrder.DESC)
             .setExpression(
@@ -316,7 +326,7 @@ public class RequestHandlerTest {
             .build(),
         orderByExpressions.get(0));
     // Should switch out the alias in the OrderBy expression
-    Assertions.assertEquals(
+    assertEquals(
         OrderByExpression.newBuilder()
             .setOrder(SortOrder.ASC)
             .setExpression(
@@ -332,5 +342,83 @@ public class RequestHandlerTest {
                                             .setColumnName("Api.Trace.metrics.duration_millis")))))
             .build(),
         orderByExpressions.get(1));
+  }
+
+  @Test
+  void shouldHandleMapAttributeExpressions() {
+    ExploreRequest exploreRequest =
+        ExploreRequest.newBuilder()
+            .setContext("SERVICE")
+            .addSelection(
+                Expression.newBuilder()
+                    .setColumnIdentifier(
+                        ColumnIdentifier.newBuilder().setColumnName("SERVICE.name")))
+            .addGroupBy(
+                Expression.newBuilder()
+                    .setAttributeExpression(
+                        AttributeExpression.newBuilder()
+                            .setAlias("SERVICE.attributes.url")
+                            .setAttributeId("SERVICE.attributes")
+                            .setSubpath("url")
+                            .build())
+                    .build())
+            .build();
+
+    ExploreRequestContext exploreRequestContext =
+        new ExploreRequestContext("customer-1", exploreRequest, Collections.emptyMap());
+
+    AttributeMetadataProvider attributeMetadataProvider = mock(AttributeMetadataProvider.class);
+    when(attributeMetadataProvider.getAttributeMetadata(
+            exploreRequestContext, "SERVICE", "startTime"))
+        .thenReturn(
+            Optional.of(AttributeMetadata.newBuilder().setFqn("SERVICE.startTime").build()));
+    when(attributeMetadataProvider.getAttributeMetadata(exploreRequestContext, "EVENT", "spaceIds"))
+        .thenReturn(Optional.of(AttributeMetadata.newBuilder().setFqn("EVENT.spaceIds").build()));
+    when(attributeMetadataProvider.getAttributesMetadata(exploreRequestContext, "SERVICE"))
+        .thenReturn(
+            Map.of(
+                "SERVICE.attributes",
+                AttributeMetadata.newBuilder()
+                    .setValueKind(AttributeKind.TYPE_STRING_MAP)
+                    .build()));
+    RequestHandler requestHandler =
+        new RequestHandler(mock(QueryServiceClient.class), 500, attributeMetadataProvider);
+    QueryRequest queryRequest =
+        requestHandler.buildQueryRequest(
+            exploreRequestContext, exploreRequest, attributeMetadataProvider);
+
+    assertEquals(
+        AttributeExpression.newBuilder()
+            .setAlias("SERVICE.attributes.url")
+            .setAttributeId("SERVICE.attributes")
+            .setSubpath("url")
+            .build(),
+        exploreRequestContext.getMapAttributeExpressionByAlias("SERVICE.attributes.url"));
+
+    org.hypertrace.core.query.service.api.Value queryServiceValue =
+        org.hypertrace.core.query.service.api.Value.newBuilder()
+            .setValueType(org.hypertrace.core.query.service.api.ValueType.STRING)
+            .setString("https://www.traceable.ai")
+            .build();
+    ColumnMetadata columnMetadata =
+        ColumnMetadata.newBuilder().setColumnName("SERVICE.attributes.url").build();
+    Row.Builder rowBuilder = Row.newBuilder();
+    requestHandler.handleQueryServiceResponseSingleColumn(
+        queryServiceValue,
+        columnMetadata,
+        rowBuilder,
+        exploreRequestContext,
+        attributeMetadataProvider);
+
+    assertEquals(
+        Row.newBuilder()
+            .putColumns(
+                "SERVICE.attributes.url",
+                Value.newBuilder()
+                    .setValueType(ValueType.STRING)
+                    .setString("https://www.traceable.ai")
+                    .build())
+            .build(),
+        rowBuilder.build());
   }
 }


### PR DESCRIPTION
## Description
Subpath attribute expressions were picking up the same value type/attribute kind as map, instead of primitive value types inside the map

Basically, if the query says 

```
url: selection(
  expression: { key: "spanTags", subpath: "url" }
) {
  value
}
```
the attribute kind for `url` becomes `TYPE_STRING_MAP`, since the attribute kind for `spanTags` is `TYPE_STRING_MAP`. This was leading to "Unable to read Map JSON String data" error, since the value for the subpath `url` isn't really a map

### Testing
Tested end to end

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules