### PR TITLE
if no time range set use entity request handler

### DIFF
--- a/gateway-service-api/src/main/proto/org/hypertrace/gateway/service/v1/explore.proto
+++ b/gateway-service-api/src/main/proto/org/hypertrace/gateway/service/v1/explore.proto
@@ -10,8 +10,8 @@ import "org/hypertrace/gateway/service/v1/gateway_query.proto";
 message ExploreRequest {
   // The context of this request eg. APIs, API Traces etc.
   string context = 1;
-  sfixed64 start_time_millis = 2;
-  sfixed64 end_time_millis = 3;
+  optional sfixed64 start_time_millis = 2;
+  optional sfixed64 end_time_millis = 3;
 
   // Filters for the WHERE clause
   org.hypertrace.gateway.service.v1.common.Filter filter = 4;

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/ExploreService.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/ExploreService.java
@@ -129,7 +129,7 @@ public class ExploreService {
               request.getGroupByList());
       Optional<String> source =
           ExpressionContext.getSingleSourceForAllAttributes(expressionContext);
-      if (source.isPresent() && EDS.toString().equals(source.get())) {
+      if ((source.isPresent() && EDS.toString().equals(source.get())) || !timeRangeSet(request)) {
         return entityRequestHandler;
       }
     }
@@ -140,6 +140,7 @@ public class ExploreService {
     if (hasTimeAggregations(request)) {
       return timeAggregationsRequestHandler;
     }
+
     return normalRequestHandler;
   }
 
@@ -149,5 +150,9 @@ public class ExploreService {
 
   private boolean hasTimeAggregationsAndGroupBy(ExploreRequest request) {
     return !request.getTimeAggregationList().isEmpty() && !request.getGroupByList().isEmpty();
+  }
+
+  private boolean timeRangeSet(ExploreRequest request) {
+    return request.getStartTimeMillis() != 0L && request.getEndTimeMillis() != 0;
   }
 }

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/ExploreService.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/ExploreService.java
@@ -24,8 +24,8 @@ import org.hypertrace.gateway.service.v1.explore.ExploreRequest;
 import org.hypertrace.gateway.service.v1.explore.ExploreResponse;
 
 public class ExploreService {
-  private static final String NO_TIME_RANGE_SPECIFIED_ERROR_MESSAGE = "Source has to set to EDS if "
-      + "no time range specified";
+  private static final String NO_TIME_RANGE_SPECIFIED_ERROR_MESSAGE =
+      "Source has to set to EDS if " + "no time range specified";
 
   private final AttributeMetadataProvider attributeMetadataProvider;
   private final ExploreRequestValidator exploreRequestValidator = new ExploreRequestValidator();

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/ExploreService.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/ExploreService.java
@@ -158,6 +158,6 @@ public class ExploreService {
   }
 
   private boolean hasTimeRange(ExploreRequest request) {
-    return request.getStartTimeMillis() != 0L && request.getEndTimeMillis() != 0L;
+    return request.hasStartTimeMillis() && request.hasEndTimeMillis();
   }
 }

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/ExploreService.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/ExploreService.java
@@ -153,6 +153,6 @@ public class ExploreService {
   }
 
   private boolean timeRangeSet(ExploreRequest request) {
-    return request.getStartTimeMillis() != 0L && request.getEndTimeMillis() != 0;
+    return request.getStartTimeMillis() != 0L && request.getEndTimeMillis() != 0L;
   }
 }

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/ExploreService.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/ExploreService.java
@@ -24,6 +24,8 @@ import org.hypertrace.gateway.service.v1.explore.ExploreRequest;
 import org.hypertrace.gateway.service.v1.explore.ExploreResponse;
 
 public class ExploreService {
+  private static final String NO_TIME_RANGE_SPECIFIED_ERROR_MESSAGE = "Source has to set to EDS if "
+      + "no time range specified";
 
   private final AttributeMetadataProvider attributeMetadataProvider;
   private final ExploreRequestValidator exploreRequestValidator = new ExploreRequestValidator();
@@ -129,8 +131,11 @@ public class ExploreService {
               request.getGroupByList());
       Optional<String> source =
           ExpressionContext.getSingleSourceForAllAttributes(expressionContext);
-      if ((source.isPresent() && EDS.toString().equals(source.get())) || !timeRangeSet(request)) {
+      if ((source.isPresent() && EDS.toString().equals(source.get())) || !hasTimeRange(request)) {
         return entityRequestHandler;
+      }
+      if ((source.isPresent() && !EDS.toString().equals(source.get())) && !hasTimeRange(request)) {
+        throw new IllegalArgumentException(NO_TIME_RANGE_SPECIFIED_ERROR_MESSAGE);
       }
     }
 
@@ -152,7 +157,7 @@ public class ExploreService {
     return !request.getTimeAggregationList().isEmpty() && !request.getGroupByList().isEmpty();
   }
 
-  private boolean timeRangeSet(ExploreRequest request) {
+  private boolean hasTimeRange(ExploreRequest request) {
     return request.getStartTimeMillis() != 0L && request.getEndTimeMillis() != 0L;
   }
 }


### PR DESCRIPTION
## Description
Make `explore` query time range params optional

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Ran modified version of service with graphql service and ran the query

### Checklist:
- [ x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
