### PR TITLE
Added boolen flag to disable time interval alignment in explore query

### DIFF
--- a/gateway-service-api/src/main/proto/org/hypertrace/gateway/service/v1/explore.proto
+++ b/gateway-service-api/src/main/proto/org/hypertrace/gateway/service/v1/explore.proto
@@ -32,6 +32,7 @@ message ExploreRequest {
   int32 offset = 21;
 
   string space_id = 22;
+  bool disable_time_interval_alignment = 23; // false by default for backward compatibility
 }
 
 message ExploreResponse {

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/TimeAggregationsRequestHandler.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/TimeAggregationsRequestHandler.java
@@ -50,7 +50,9 @@ public class TimeAggregationsRequestHandler extends RequestHandler {
     QueryRequest.Builder builder = QueryRequest.newBuilder();
 
     // 1. Align the startTime and endTime with period boundaries if there are TimeAggregations
-    request = createPeriodBoundaryAlignedExploreRequest(request);
+    if (!request.getDisableTimeIntervalAlignment()) {
+      request = createPeriodBoundaryAlignedExploreRequest(request);
+    }
 
     // 2. Add filter
     builder.setFilter(


### PR DESCRIPTION
Explore query, by default, aligns the time range to the queried time interval.
However, in certain cases, results based on the queried time-range are required, which means no alignment.
Added a field in explore-request to allow this.