### PR TITLE
refactor: parallelize total entities query

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/EntityService.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/EntityService.java
@@ -64,6 +64,7 @@ public class EntityService {
       new BulkUpdateEntitiesRequestValidator();
   private final AttributeMetadataProvider metadataProvider;
   private final EntityIdColumnsConfigs entityIdColumnsConfigs;
+  private ExecutorService queryExecutor;
   private final EntityInteractionsFetcher interactionsFetcher;
   private final RequestPreProcessor requestPreProcessor;
   private final ResponsePostProcessor responsePostProcessor;
@@ -84,6 +85,7 @@ public class EntityService {
       ExecutorService queryExecutor) {
     this.metadataProvider = metadataProvider;
     this.entityIdColumnsConfigs = entityIdColumnsConfigs;
+    this.queryExecutor = queryExecutor;
     this.interactionsFetcher =
         new EntityInteractionsFetcher(qsClient, qsRequestTimeout, metadataProvider, queryExecutor);
     this.requestPreProcessor = new RequestPreProcessor(metadataProvider, scopeFilterConfigs);
@@ -167,7 +169,8 @@ public class EntityService {
      */
     EntityResponse response =
         executionTree.acceptVisitor(
-            new ExecutionVisitor(executionContext, EntityQueryHandlerRegistry.get()));
+            new ExecutionVisitor(
+                executionContext, EntityQueryHandlerRegistry.get(), this.queryExecutor));
 
     EntityFetcherResponse entityFetcherResponse = response.getEntityFetcherResponse();
 

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitorTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitorTest.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hypertrace.core.attribute.service.v1.AttributeScope;
@@ -133,7 +134,9 @@ public class ExecutionVisitorTest {
         .thenReturn(queryServiceEntityFetcher);
     when(entityQueryHandlerRegistry.getEntityFetcher(EDS_SOURCE))
         .thenReturn(entityDataServiceEntityFetcher);
-    executionVisitor = new ExecutionVisitor(executionContext, entityQueryHandlerRegistry);
+    executionVisitor =
+        new ExecutionVisitor(
+            executionContext, entityQueryHandlerRegistry, Executors.newSingleThreadExecutor());
   }
 
   @Test
@@ -756,7 +759,9 @@ public class ExecutionVisitorTest {
   @Test
   public void test_visitSelectionNode_differentSource_callSeparatedCalls() {
     ExecutionVisitor executionVisitor =
-        spy(new ExecutionVisitor(executionContext, entityQueryHandlerRegistry));
+        spy(
+            new ExecutionVisitor(
+                executionContext, entityQueryHandlerRegistry, Executors.newSingleThreadExecutor()));
     when(executionContext.getTimestampAttributeId()).thenReturn("API.startTime");
     SelectionNode selectionNode =
         new SelectionNode.Builder(new NoOpNode())
@@ -925,7 +930,9 @@ public class ExecutionVisitorTest {
             .setFilter(generateEQFilter(API_DISCOVERY_STATE, "DISCOVERED"))
             .build();
     ExecutionVisitor executionVisitor =
-        spy(new ExecutionVisitor(executionContext, entityQueryHandlerRegistry));
+        spy(
+            new ExecutionVisitor(
+                executionContext, entityQueryHandlerRegistry, Executors.newSingleThreadExecutor()));
     when(executionContext.getEntitiesRequest()).thenReturn(entitiesRequest);
 
     // Selection node with NoOp child, to short-circuit the call to first service.


### PR DESCRIPTION
## Description
Updated entity service to parallelize the query for total entity count as that is not required to perform other entity data query.

### Testing
Unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
