### PR TITLE
refactor: use channel registry, swap to own query client

### DIFF
--- a/gateway-service-factory/src/main/java/org/hypertrace/gateway/service/GatewayServiceFactory.java
+++ b/gateway-service-factory/src/main/java/org/hypertrace/gateway/service/GatewayServiceFactory.java
@@ -11,6 +11,8 @@ public class GatewayServiceFactory implements GrpcPlatformServiceFactory {
   @Override
   public List<GrpcPlatformService> buildServices(GrpcServiceContainerEnvironment environment) {
     return List.of(
-        new GrpcPlatformService(new GatewayServiceImpl(environment.getConfig(SERVICE_NAME))));
+        new GrpcPlatformService(
+            new GatewayServiceImpl(
+                environment.getConfig(SERVICE_NAME), environment.getChannelRegistry())));
   }
 }

--- a/gateway-service-impl/build.gradle.kts
+++ b/gateway-service-impl/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
   implementation("org.hypertrace.entity.service:entity-service-client:0.8.27")
   implementation("org.hypertrace.entity.service:entity-service-api:0.8.27")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.7.5")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.7.5")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.35")
 
   // Config

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/baseline/BaselineRequestContext.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/baseline/BaselineRequestContext.java
@@ -7,10 +7,11 @@ import org.hypertrace.gateway.service.v1.baseline.BaselineTimeAggregation;
 
 public class BaselineRequestContext extends RequestContext {
 
-  private final Map<String, BaselineTimeAggregation> aliasToTimeAggregation = new HashMap();
+  private final Map<String, BaselineTimeAggregation> aliasToTimeAggregation = new HashMap<>();
 
-  public BaselineRequestContext(String tenantId, Map<String, String> headers) {
-    super(tenantId, headers);
+  public BaselineRequestContext(
+      org.hypertrace.core.grpcutils.context.RequestContext grpcRequestContext) {
+    super(grpcRequestContext);
   }
 
   public void mapAliasToTimeAggregation(String alias, BaselineTimeAggregation timeAggregation) {

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/baseline/BaselineService.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/baseline/BaselineService.java
@@ -1,10 +1,10 @@
 package org.hypertrace.gateway.service.baseline;
 
-import java.util.Map;
+import org.hypertrace.gateway.service.common.RequestContext;
 import org.hypertrace.gateway.service.v1.baseline.BaselineEntitiesRequest;
 import org.hypertrace.gateway.service.v1.baseline.BaselineEntitiesResponse;
 
 public interface BaselineService {
   BaselineEntitiesResponse getBaselineForEntities(
-      String tenantId, BaselineEntitiesRequest originalRequest, Map<String, String> requestHeaders);
+      RequestContext requestContext, BaselineEntitiesRequest originalRequest);
 }

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/baseline/BaselineServiceQueryExecutor.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/baseline/BaselineServiceQueryExecutor.java
@@ -1,23 +1,20 @@
 package org.hypertrace.gateway.service.baseline;
 
 import java.util.Iterator;
-import java.util.Map;
 import org.hypertrace.core.query.service.api.QueryRequest;
 import org.hypertrace.core.query.service.api.ResultSetChunk;
-import org.hypertrace.core.query.service.client.QueryServiceClient;
+import org.hypertrace.gateway.service.common.RequestContext;
+import org.hypertrace.gateway.service.common.util.QueryServiceClient;
 
 public class BaselineServiceQueryExecutor {
-
-  private final int qsRequestTimeout;
   private final QueryServiceClient queryServiceClient;
 
-  public BaselineServiceQueryExecutor(int qsRequestTimeout, QueryServiceClient queryServiceClient) {
-    this.qsRequestTimeout = qsRequestTimeout;
+  public BaselineServiceQueryExecutor(QueryServiceClient queryServiceClient) {
     this.queryServiceClient = queryServiceClient;
   }
 
   public Iterator<ResultSetChunk> executeQuery(
-      Map<String, String> requestHeaders, QueryRequest aggQueryRequest) {
-    return queryServiceClient.executeQuery(aggQueryRequest, requestHeaders, qsRequestTimeout);
+      RequestContext requestContext, QueryRequest aggQueryRequest) {
+    return queryServiceClient.executeQuery(requestContext, aggQueryRequest);
   }
 }

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/QueryRequestContext.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/QueryRequestContext.java
@@ -14,8 +14,10 @@ public class QueryRequestContext extends RequestContext {
   private final Map<String, TimeAggregation> aliasToTimeAggregation = new HashMap<>();
 
   public QueryRequestContext(
-      String tenantId, long startTimeMillis, long endTimeMillis, Map<String, String> headers) {
-    super(tenantId, headers);
+      org.hypertrace.core.grpcutils.context.RequestContext requestContext,
+      long startTimeMillis,
+      long endTimeMillis) {
+    super(requestContext);
     this.startTimeMillis = startTimeMillis;
     this.endTimeMillis = endTimeMillis;
   }

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/RequestContext.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/RequestContext.java
@@ -8,20 +8,22 @@ import java.util.Objects;
  * example is the incoming tenant id and request headers. Extend this class as you would like.
  */
 public class RequestContext {
-  private final String tenantId;
-  private final Map<String, String> headers;
+  private org.hypertrace.core.grpcutils.context.RequestContext grpcContext;
 
-  public RequestContext(String tenantId, Map<String, String> headers) {
-    this.tenantId = tenantId;
-    this.headers = headers;
+  public RequestContext(org.hypertrace.core.grpcutils.context.RequestContext grpcContext) {
+    this.grpcContext = grpcContext;
   }
 
   public String getTenantId() {
-    return tenantId;
+    return grpcContext.getTenantId().orElseThrow();
   }
 
   public Map<String, String> getHeaders() {
-    return headers;
+    return grpcContext.getRequestHeaders();
+  }
+
+  public org.hypertrace.core.grpcutils.context.RequestContext getGrpcContext() {
+    return grpcContext;
   }
 
   @Override
@@ -29,11 +31,11 @@ public class RequestContext {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     RequestContext that = (RequestContext) o;
-    return Objects.equals(tenantId, that.tenantId) && Objects.equals(headers, that.headers);
+    return Objects.equals(this.getHeaders(), that.getHeaders());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(tenantId, headers);
+    return Objects.hash(this.getHeaders());
   }
 }

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/util/QueryServiceClient.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/util/QueryServiceClient.java
@@ -1,0 +1,34 @@
+package org.hypertrace.gateway.service.common.util;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import java.time.Duration;
+import java.util.Iterator;
+import org.hypertrace.core.query.service.api.QueryRequest;
+import org.hypertrace.core.query.service.api.QueryServiceGrpc.QueryServiceBlockingStub;
+import org.hypertrace.core.query.service.api.ResultSetChunk;
+import org.hypertrace.gateway.service.common.RequestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class QueryServiceClient {
+  private static final Logger LOG = LoggerFactory.getLogger(QueryServiceClient.class);
+  private final QueryServiceBlockingStub stub;
+  private final Duration timeoutDuration;
+
+  public QueryServiceClient(QueryServiceBlockingStub stub, Duration timeoutDuration) {
+    this.stub = stub;
+    this.timeoutDuration = timeoutDuration;
+  }
+
+  public Iterator<ResultSetChunk> executeQuery(
+      RequestContext requestContext, QueryRequest request) {
+
+    LOG.debug("Sending query to query service with request: {}", request);
+    return requestContext
+        .getGrpcContext()
+        .call(
+            () ->
+                stub.withDeadlineAfter(timeoutDuration.toMillis(), MILLISECONDS).execute(request));
+  }
+}

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/EntitiesRequestContext.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/EntitiesRequestContext.java
@@ -1,7 +1,7 @@
 package org.hypertrace.gateway.service.entity;
 
-import java.util.Map;
 import java.util.Objects;
+import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.gateway.service.common.QueryRequestContext;
 
 public class EntitiesRequestContext extends QueryRequestContext {
@@ -9,13 +9,12 @@ public class EntitiesRequestContext extends QueryRequestContext {
   private final String timestampAttributeId;
 
   public EntitiesRequestContext(
-      String tenantId,
+      RequestContext requestContext,
       long startTimeMillis,
       long endTimeMillis,
       String entityType,
-      String timestampAttributeId,
-      Map<String, String> requestHeaders) {
-    super(tenantId, startTimeMillis, endTimeMillis, requestHeaders);
+      String timestampAttributeId) {
+    super(requestContext, startTimeMillis, endTimeMillis);
     this.entityType = entityType;
     this.timestampAttributeId = timestampAttributeId;
   }

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitor.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitor.java
@@ -122,12 +122,11 @@ public class ExecutionVisitor implements Visitor<EntityResponse> {
     EntitiesRequest entitiesRequest = executionContext.getEntitiesRequest();
     EntitiesRequestContext context =
         new EntitiesRequestContext(
-            executionContext.getTenantId(),
+            executionContext.getEntitiesRequestContext().getGrpcContext(),
             entitiesRequest.getStartTimeMillis(),
             entitiesRequest.getEndTimeMillis(),
             entitiesRequest.getEntityType(),
-            executionContext.getTimestampAttributeId(),
-            executionContext.getRequestHeaders());
+            executionContext.getTimestampAttributeId());
 
     EntitiesRequest.Builder requestBuilder =
         EntitiesRequest.newBuilder(entitiesRequest)
@@ -239,12 +238,11 @@ public class ExecutionVisitor implements Visitor<EntityResponse> {
                   IEntityFetcher entityFetcher = queryHandlerRegistry.getEntityFetcher(source);
                   EntitiesRequestContext context =
                       new EntitiesRequestContext(
-                          executionContext.getTenantId(),
+                          executionContext.getEntitiesRequestContext().getGrpcContext(),
                           request.getStartTimeMillis(),
                           request.getEndTimeMillis(),
                           request.getEntityType(),
-                          executionContext.getTimestampAttributeId(),
-                          executionContext.getRequestHeaders());
+                          executionContext.getTimestampAttributeId());
                   return entityFetcher.getEntities(context, request);
                 })
             .collect(Collectors.toList()));
@@ -270,12 +268,11 @@ public class ExecutionVisitor implements Visitor<EntityResponse> {
                   IEntityFetcher entityFetcher = queryHandlerRegistry.getEntityFetcher(source);
                   EntitiesRequestContext context =
                       new EntitiesRequestContext(
-                          executionContext.getTenantId(),
+                          executionContext.getEntitiesRequestContext().getGrpcContext(),
                           request.getStartTimeMillis(),
                           request.getEndTimeMillis(),
                           request.getEntityType(),
-                          executionContext.getTimestampAttributeId(),
-                          executionContext.getRequestHeaders());
+                          executionContext.getTimestampAttributeId());
                   return entityFetcher.getEntities(context, request);
                 })
             .collect(Collectors.toList()));
@@ -301,12 +298,11 @@ public class ExecutionVisitor implements Visitor<EntityResponse> {
                   IEntityFetcher entityFetcher = queryHandlerRegistry.getEntityFetcher(source);
                   EntitiesRequestContext requestContext =
                       new EntitiesRequestContext(
-                          executionContext.getTenantId(),
+                          executionContext.getEntitiesRequestContext().getGrpcContext(),
                           request.getStartTimeMillis(),
                           request.getEndTimeMillis(),
                           request.getEntityType(),
-                          executionContext.getTimestampAttributeId(),
-                          executionContext.getRequestHeaders());
+                          executionContext.getTimestampAttributeId());
                   return entityFetcher.getTimeAggregatedMetrics(requestContext, request);
                 })
             .collect(Collectors.toList()));

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/ExploreRequestContext.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/ExploreRequestContext.java
@@ -3,7 +3,7 @@ package org.hypertrace.gateway.service.explore;
 import static org.hypertrace.core.query.service.client.QueryServiceClient.DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT;
 
 import java.util.List;
-import java.util.Map;
+import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.gateway.service.common.QueryRequestContext;
 import org.hypertrace.gateway.service.v1.common.OrderByExpression;
 import org.hypertrace.gateway.service.v1.explore.ExploreRequest;
@@ -14,13 +14,9 @@ public class ExploreRequestContext extends QueryRequestContext {
   private boolean hasGroupBy = false;
   private List<OrderByExpression> orderByExpressions;
 
-  public ExploreRequestContext(
-      String tenantId, ExploreRequest exploreRequest, Map<String, String> requestHeaders) {
+  public ExploreRequestContext(RequestContext grpcRequestContext, ExploreRequest exploreRequest) {
     super(
-        tenantId,
-        exploreRequest.getStartTimeMillis(),
-        exploreRequest.getEndTimeMillis(),
-        requestHeaders);
+        grpcRequestContext, exploreRequest.getStartTimeMillis(), exploreRequest.getEndTimeMillis());
 
     this.exploreRequest = exploreRequest;
     this.orderByExpressions = exploreRequest.getOrderByList();

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/TheRestGroupRequestHandler.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/TheRestGroupRequestHandler.java
@@ -46,7 +46,7 @@ public class TheRestGroupRequestHandler {
 
     ExploreRequest theRestRequest = createRequest(originalRequest, originalResponse);
     ExploreRequestContext theRestRequestContext =
-        new ExploreRequestContext(context.getTenantId(), theRestRequest, context.getHeaders());
+        new ExploreRequestContext(context.getGrpcContext(), theRestRequest);
 
     ExploreResponse.Builder theRestGroupResponse =
         requestHandler.handleRequest(theRestRequestContext, theRestRequest);

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/TimeAggregationsRequestHandler.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/TimeAggregationsRequestHandler.java
@@ -12,12 +12,12 @@ import org.hypertrace.core.query.service.api.QueryRequest;
 import org.hypertrace.core.query.service.api.ResultSetMetadata;
 import org.hypertrace.core.query.service.api.Row;
 import org.hypertrace.core.query.service.api.Value;
-import org.hypertrace.core.query.service.client.QueryServiceClient;
 import org.hypertrace.gateway.service.common.AttributeMetadataProvider;
 import org.hypertrace.gateway.service.common.converters.QueryAndGatewayDtoConverter;
 import org.hypertrace.gateway.service.common.util.AttributeMetadataUtil;
 import org.hypertrace.gateway.service.common.util.ExpressionReader;
 import org.hypertrace.gateway.service.common.util.QueryExpressionUtil;
+import org.hypertrace.gateway.service.common.util.QueryServiceClient;
 import org.hypertrace.gateway.service.v1.common.OrderByExpression;
 import org.hypertrace.gateway.service.v1.common.Period;
 import org.hypertrace.gateway.service.v1.common.SortOrder;
@@ -33,10 +33,8 @@ public class TimeAggregationsRequestHandler extends RequestHandler {
   private static final Logger LOG = LoggerFactory.getLogger(TimeAggregationsRequestHandler.class);
 
   TimeAggregationsRequestHandler(
-      QueryServiceClient queryServiceClient,
-      int qsRequestTimeout,
-      AttributeMetadataProvider attributeMetadataProvider) {
-    super(queryServiceClient, qsRequestTimeout, attributeMetadataProvider);
+      QueryServiceClient queryServiceClient, AttributeMetadataProvider attributeMetadataProvider) {
+    super(queryServiceClient, attributeMetadataProvider);
   }
 
   @Override

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/TimeAggregationsWithGroupByRequestHandler.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/TimeAggregationsWithGroupByRequestHandler.java
@@ -2,9 +2,9 @@ package org.hypertrace.gateway.service.explore;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
-import org.hypertrace.core.query.service.client.QueryServiceClient;
 import org.hypertrace.gateway.service.common.AttributeMetadataProvider;
 import org.hypertrace.gateway.service.common.util.ExpressionReader;
+import org.hypertrace.gateway.service.common.util.QueryServiceClient;
 import org.hypertrace.gateway.service.v1.common.Expression;
 import org.hypertrace.gateway.service.v1.common.Filter;
 import org.hypertrace.gateway.service.v1.common.LiteralConstant;
@@ -20,14 +20,10 @@ public class TimeAggregationsWithGroupByRequestHandler implements IRequestHandle
   private final TimeAggregationsRequestHandler timeAggregationsRequestHandler;
 
   TimeAggregationsWithGroupByRequestHandler(
-      QueryServiceClient queryServiceClient,
-      int requestTimeout,
-      AttributeMetadataProvider attributeMetadataProvider) {
-    this.normalRequestHandler =
-        new RequestHandler(queryServiceClient, requestTimeout, attributeMetadataProvider);
+      QueryServiceClient queryServiceClient, AttributeMetadataProvider attributeMetadataProvider) {
+    this.normalRequestHandler = new RequestHandler(queryServiceClient, attributeMetadataProvider);
     this.timeAggregationsRequestHandler =
-        new TimeAggregationsRequestHandler(
-            queryServiceClient, requestTimeout, attributeMetadataProvider);
+        new TimeAggregationsRequestHandler(queryServiceClient, attributeMetadataProvider);
   }
 
   @Override
@@ -38,8 +34,7 @@ public class TimeAggregationsWithGroupByRequestHandler implements IRequestHandle
     // 1. Create a GroupBy request and get the response for the GroupBy
     ExploreRequest groupByRequest = buildGroupByRequest(request);
     ExploreRequestContext groupByRequestContext =
-        new ExploreRequestContext(
-            requestContext.getTenantId(), groupByRequest, requestContext.getHeaders());
+        new ExploreRequestContext(requestContext.getGrpcContext(), groupByRequest);
     ExploreResponse.Builder groupByResponse =
         normalRequestHandler.handleRequest(groupByRequestContext, groupByRequest);
 
@@ -52,8 +47,7 @@ public class TimeAggregationsWithGroupByRequestHandler implements IRequestHandle
     // the actual query response
     ExploreRequest timeAggregationsRequest = buildTimeAggregationsRequest(request, groupByResponse);
     ExploreRequestContext timeAggregationsRequestContext =
-        new ExploreRequestContext(
-            requestContext.getTenantId(), timeAggregationsRequest, requestContext.getHeaders());
+        new ExploreRequestContext(requestContext.getGrpcContext(), timeAggregationsRequest);
     ExploreResponse.Builder timeAggregationsResponse =
         timeAggregationsRequestHandler.handleRequest(
             timeAggregationsRequestContext, timeAggregationsRequest);

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/logevent/LogEventsService.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/logevent/LogEventsService.java
@@ -17,12 +17,12 @@ import org.hypertrace.core.query.service.api.QueryRequest;
 import org.hypertrace.core.query.service.api.ResultSetChunk;
 import org.hypertrace.core.query.service.api.ResultSetMetadata;
 import org.hypertrace.core.query.service.api.Row;
-import org.hypertrace.core.query.service.client.QueryServiceClient;
 import org.hypertrace.core.serviceframework.metrics.PlatformMetricsRegistry;
 import org.hypertrace.gateway.service.common.AttributeMetadataProvider;
 import org.hypertrace.gateway.service.common.RequestContext;
 import org.hypertrace.gateway.service.common.converters.QueryAndGatewayDtoConverter;
 import org.hypertrace.gateway.service.common.util.AttributeMetadataUtil;
+import org.hypertrace.gateway.service.common.util.QueryServiceClient;
 import org.hypertrace.gateway.service.v1.common.OrderByExpression;
 import org.hypertrace.gateway.service.v1.log.events.LogEvent;
 import org.hypertrace.gateway.service.v1.log.events.LogEventsRequest;
@@ -36,17 +36,13 @@ public class LogEventsService {
 
   private static final String LOG_EVENT_SCOPE = "LOG_EVENT";
   private final QueryServiceClient queryServiceClient;
-  private final int requestTimeout;
   private final AttributeMetadataProvider attributeMetadataProvider;
 
   private Timer queryExecutionTimer;
 
   public LogEventsService(
-      QueryServiceClient queryServiceClient,
-      int requestTimeout,
-      AttributeMetadataProvider attributeMetadataProvider) {
+      QueryServiceClient queryServiceClient, AttributeMetadataProvider attributeMetadataProvider) {
     this.queryServiceClient = queryServiceClient;
-    this.requestTimeout = requestTimeout;
     this.attributeMetadataProvider = attributeMetadataProvider;
     initMetrics();
   }
@@ -116,7 +112,7 @@ public class LogEventsService {
     QueryRequest queryRequest = queryBuilder.build();
 
     Iterator<ResultSetChunk> resultSetChunkIterator =
-        queryServiceClient.executeQuery(queryRequest, context.getHeaders(), requestTimeout);
+        queryServiceClient.executeQuery(context, queryRequest);
 
     ResultSetMetadata resultSetMetadata = null;
     while (resultSetChunkIterator.hasNext()) {

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/span/SpanService.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/span/SpanService.java
@@ -24,12 +24,12 @@ import org.hypertrace.core.query.service.api.Filter;
 import org.hypertrace.core.query.service.api.QueryRequest;
 import org.hypertrace.core.query.service.api.ResultSetChunk;
 import org.hypertrace.core.query.service.api.Row;
-import org.hypertrace.core.query.service.client.QueryServiceClient;
 import org.hypertrace.core.serviceframework.metrics.PlatformMetricsRegistry;
 import org.hypertrace.gateway.service.common.AttributeMetadataProvider;
 import org.hypertrace.gateway.service.common.RequestContext;
 import org.hypertrace.gateway.service.common.converters.QueryAndGatewayDtoConverter;
 import org.hypertrace.gateway.service.common.util.AttributeMetadataUtil;
+import org.hypertrace.gateway.service.common.util.QueryServiceClient;
 import org.hypertrace.gateway.service.v1.common.OrderByExpression;
 import org.hypertrace.gateway.service.v1.span.SpanEvent;
 import org.hypertrace.gateway.service.v1.span.SpansRequest;
@@ -45,7 +45,6 @@ public class SpanService {
 
   private static final Logger LOG = LoggerFactory.getLogger(SpanService.class);
   private final QueryServiceClient queryServiceClient;
-  private final int requestTimeout;
   private final AttributeMetadataProvider attributeMetadataProvider;
   private final ExecutorService queryExecutor;
 
@@ -53,11 +52,9 @@ public class SpanService {
 
   public SpanService(
       QueryServiceClient queryServiceClient,
-      int requestTimeout,
       AttributeMetadataProvider attributeMetadataProvider,
       ExecutorService queryExecutor) {
     this.queryServiceClient = queryServiceClient;
-    this.requestTimeout = requestTimeout;
     this.attributeMetadataProvider = attributeMetadataProvider;
     this.queryExecutor = queryExecutor;
     initMetrics();
@@ -126,7 +123,7 @@ public class SpanService {
     QueryRequest queryRequest = queryBuilder.build();
 
     Iterator<ResultSetChunk> resultSetChunkIterator =
-        queryServiceClient.executeQuery(queryRequest, context.getHeaders(), requestTimeout);
+        queryServiceClient.executeQuery(context, queryRequest);
 
     while (resultSetChunkIterator.hasNext()) {
       ResultSetChunk chunk = resultSetChunkIterator.next();
@@ -200,7 +197,7 @@ public class SpanService {
             .build();
 
     Iterator<ResultSetChunk> resultSetChunkIterator =
-        queryServiceClient.executeQuery(queryRequest, context.getHeaders(), requestTimeout);
+        queryServiceClient.executeQuery(context, queryRequest);
     while (resultSetChunkIterator.hasNext()) {
       ResultSetChunk chunk = resultSetChunkIterator.next();
       if (LOG.isDebugEnabled()) {

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/trace/TracesService.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/trace/TracesService.java
@@ -1,5 +1,6 @@
 package org.hypertrace.gateway.service.trace;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hypertrace.gateway.service.common.converters.QueryRequestUtil.createCountByColumnSelection;
 import static org.hypertrace.gateway.service.common.util.AttributeMetadataUtil.getSpaceAttributeId;
 import static org.hypertrace.gateway.service.common.util.AttributeMetadataUtil.getTimestampAttributeId;
@@ -15,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
 import org.hypertrace.core.query.service.api.ColumnMetadata;
 import org.hypertrace.core.query.service.api.Filter;
@@ -23,7 +23,6 @@ import org.hypertrace.core.query.service.api.QueryRequest;
 import org.hypertrace.core.query.service.api.QueryRequest.Builder;
 import org.hypertrace.core.query.service.api.ResultSetChunk;
 import org.hypertrace.core.query.service.api.Row;
-import org.hypertrace.core.query.service.client.QueryServiceClient;
 import org.hypertrace.core.serviceframework.metrics.PlatformMetricsRegistry;
 import org.hypertrace.gateway.service.common.AttributeMetadataProvider;
 import org.hypertrace.gateway.service.common.RequestContext;
@@ -32,6 +31,7 @@ import org.hypertrace.gateway.service.common.converters.QueryAndGatewayDtoConver
 import org.hypertrace.gateway.service.common.transformer.RequestPreProcessor;
 import org.hypertrace.gateway.service.common.util.AttributeMetadataUtil;
 import org.hypertrace.gateway.service.common.util.ExpressionReader;
+import org.hypertrace.gateway.service.common.util.QueryServiceClient;
 import org.hypertrace.gateway.service.v1.common.OrderByExpression;
 import org.hypertrace.gateway.service.v1.trace.Trace;
 import org.hypertrace.gateway.service.v1.trace.TracesRequest;
@@ -55,7 +55,6 @@ public class TracesService {
   private static final Logger LOG = LoggerFactory.getLogger(TracesService.class);
 
   private final QueryServiceClient queryServiceClient;
-  private final int queryServiceReqTimeout;
   private final AttributeMetadataProvider attributeMetadataProvider;
   private final ExecutorService queryExecutor;
   private final TracesRequestValidator requestValidator;
@@ -65,12 +64,10 @@ public class TracesService {
 
   public TracesService(
       QueryServiceClient queryServiceClient,
-      int qsRequestTimeout,
       AttributeMetadataProvider attributeMetadataProvider,
       ScopeFilterConfigs scopeFilterConfigs,
       ExecutorService queryExecutor) {
     this.queryServiceClient = queryServiceClient;
-    this.queryServiceReqTimeout = qsRequestTimeout;
     this.attributeMetadataProvider = attributeMetadataProvider;
     this.queryExecutor = queryExecutor;
     this.requestValidator = new TracesRequestValidator();
@@ -113,8 +110,7 @@ public class TracesService {
 
       return response;
     } finally {
-      queryExecutionTimer.record(
-          Duration.between(start, Instant.now()).toMillis(), TimeUnit.MILLISECONDS);
+      queryExecutionTimer.record(Duration.between(start, Instant.now()).toMillis(), MILLISECONDS);
     }
   }
 
@@ -145,7 +141,7 @@ public class TracesService {
     List<Trace> tracesResult = new ArrayList<>();
     QueryRequest queryRequest = builder.build();
     Iterator<ResultSetChunk> resultSetChunkIterator =
-        queryServiceClient.executeQuery(queryRequest, context.getHeaders(), queryServiceReqTimeout);
+        queryServiceClient.executeQuery(context, queryRequest);
 
     // form the result
     while (resultSetChunkIterator.hasNext()) {
@@ -191,8 +187,9 @@ public class TracesService {
             .addSelection(createCountByColumnSelection(firstSelectionAttributeId))
             .setLimit(1)
             .build();
+
     Iterator<ResultSetChunk> resultSetChunkIterator =
-        queryServiceClient.executeQuery(queryRequest, context.getHeaders(), queryServiceReqTimeout);
+        queryServiceClient.executeQuery(context, queryRequest);
     while (resultSetChunkIterator.hasNext()) {
       ResultSetChunk chunk = resultSetChunkIterator.next();
       if (LOG.isDebugEnabled()) {

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/GatewayServiceImplTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/GatewayServiceImplTest.java
@@ -3,6 +3,7 @@ package org.hypertrace.gateway.service;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.io.File;
+import org.hypertrace.core.grpcutils.client.GrpcChannelRegistry;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -27,6 +28,6 @@ public class GatewayServiceImplTest {
 
   @Test
   public void testServiceImplInitialization() {
-    new GatewayServiceImpl(appConfig);
+    new GatewayServiceImpl(appConfig, new GrpcChannelRegistry());
   }
 }

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/baseline/BaselineServiceImplTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/baseline/BaselineServiceImplTest.java
@@ -1,7 +1,9 @@
 package org.hypertrace.gateway.service.baseline;
 
+import static org.hypertrace.core.grpcutils.context.RequestContext.forTenantId;
 import static org.hypertrace.gateway.service.baseline.BaselineServiceImpl.DAY_IN_MILLIS;
 import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.getResultSetChunk;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -66,11 +68,11 @@ public class BaselineServiceImplTest {
         AttributeMetadata.newBuilder().setFqn("Service.Latency").setId("Service.StartTime").build();
     Mockito.when(
             attributeMetadataProvider.getAttributeMetadata(
-                Mockito.any(RequestContext.class), Mockito.anyString(), Mockito.anyString()))
+                any(RequestContext.class), Mockito.anyString(), Mockito.anyString()))
         .thenReturn(Optional.of(attributeMetadata));
     Mockito.when(
             baselineServiceQueryExecutor.executeQuery(
-                Mockito.anyMap(), Mockito.any(QueryRequest.class)))
+                any(RequestContext.class), any(QueryRequest.class)))
         .thenReturn(getResultSetForAvg("duration_ts").iterator());
     when(entityIdColumnsConfigs.getIdKey("SERVICE")).thenReturn(Optional.of("id"));
 
@@ -83,7 +85,7 @@ public class BaselineServiceImplTest {
         AttributeMetadata.newBuilder().setFqn("Service.Latency").setId("Service.Id").build());
     Mockito.when(
             attributeMetadataProvider.getAttributesMetadata(
-                Mockito.any(RequestContext.class), Mockito.anyString()))
+                any(RequestContext.class), Mockito.anyString()))
         .thenReturn(attributeMap);
 
     BaselineService baselineService =
@@ -93,7 +95,8 @@ public class BaselineServiceImplTest {
             baselineServiceQueryExecutor,
             entityIdColumnsConfigs);
     BaselineEntitiesResponse baselineResponse =
-        baselineService.getBaselineForEntities(TENANT_ID, baselineEntitiesRequest, Map.of());
+        baselineService.getBaselineForEntities(
+            new RequestContext(forTenantId(TENANT_ID)), baselineEntitiesRequest);
     Assertions.assertTrue(baselineResponse.getBaselineEntityCount() > 0);
     Assertions.assertTrue(
         baselineResponse.getBaselineEntityList().get(0).getBaselineAggregateMetricCount() > 0);
@@ -117,11 +120,11 @@ public class BaselineServiceImplTest {
         AttributeMetadata.newBuilder().setFqn("Service.numCalls").setId("Service.Id").build();
     Mockito.when(
             attributeMetadataProvider.getAttributeMetadata(
-                Mockito.any(RequestContext.class), Mockito.anyString(), Mockito.anyString()))
+                any(RequestContext.class), Mockito.anyString(), Mockito.anyString()))
         .thenReturn(Optional.of(attributeMetadata));
     Mockito.when(
             baselineServiceQueryExecutor.executeQuery(
-                Mockito.anyMap(), Mockito.any(QueryRequest.class)))
+                any(RequestContext.class), any(QueryRequest.class)))
         .thenReturn(getResultSetForAvgRate("numCalls").iterator());
     when(entityIdColumnsConfigs.getIdKey("SERVICE")).thenReturn(Optional.of("id"));
     // Attribute Metadata map contains mapping between Attributes and ID to query data.
@@ -131,7 +134,7 @@ public class BaselineServiceImplTest {
         AttributeMetadata.newBuilder().setFqn("Service.numCalls").setId("Service.Id").build());
     Mockito.when(
             attributeMetadataProvider.getAttributesMetadata(
-                Mockito.any(RequestContext.class), Mockito.anyString()))
+                any(RequestContext.class), Mockito.anyString()))
         .thenReturn(attributeMap);
 
     BaselineService baselineService =
@@ -141,7 +144,8 @@ public class BaselineServiceImplTest {
             baselineServiceQueryExecutor,
             entityIdColumnsConfigs);
     BaselineEntitiesResponse baselineResponse =
-        baselineService.getBaselineForEntities(TENANT_ID, baselineEntitiesRequest, Map.of());
+        baselineService.getBaselineForEntities(
+            new RequestContext(forTenantId(TENANT_ID)), baselineEntitiesRequest);
     Assertions.assertTrue(baselineResponse.getBaselineEntityCount() > 0);
     Assertions.assertTrue(
         baselineResponse.getBaselineEntityList().get(0).getBaselineAggregateMetricCount() > 0);
@@ -166,11 +170,11 @@ public class BaselineServiceImplTest {
         AttributeMetadata.newBuilder().setFqn("Service.Latency").setId("Service.StartTime").build();
     Mockito.when(
             attributeMetadataProvider.getAttributeMetadata(
-                Mockito.any(RequestContext.class), Mockito.anyString(), Mockito.anyString()))
+                any(RequestContext.class), Mockito.anyString(), Mockito.anyString()))
         .thenReturn(Optional.of(attributeMetadata));
     Mockito.when(
             baselineServiceQueryExecutor.executeQuery(
-                Mockito.anyMap(), Mockito.any(QueryRequest.class)))
+                any(RequestContext.class), any(QueryRequest.class)))
         .thenReturn(getResultSetForAvg("duration_ts").iterator());
     Map<String, AttributeMetadata> attributeMap = new HashMap<>();
     AttributeMetadata attribute =
@@ -179,11 +183,11 @@ public class BaselineServiceImplTest {
     attributeMap.put("SERVICE.duration", attribute);
     Mockito.when(
             attributeMetadataProvider.getAttributesMetadata(
-                Mockito.any(RequestContext.class), Mockito.anyString()))
+                any(RequestContext.class), Mockito.anyString()))
         .thenReturn(attributeMap);
     Mockito.when(
             attributeMetadataProvider.getAttributeMetadata(
-                Mockito.any(RequestContext.class), Mockito.anyString(), Mockito.anyString()))
+                any(RequestContext.class), Mockito.anyString(), Mockito.anyString()))
         .thenReturn(Optional.of(attribute));
     when(entityIdColumnsConfigs.getIdKey("SERVICE")).thenReturn(Optional.of("id"));
 
@@ -194,7 +198,8 @@ public class BaselineServiceImplTest {
             baselineServiceQueryExecutor,
             entityIdColumnsConfigs);
     BaselineEntitiesResponse baselineResponse =
-        baselineService.getBaselineForEntities(TENANT_ID, baselineEntitiesRequest, Map.of());
+        baselineService.getBaselineForEntities(
+            new RequestContext(forTenantId(TENANT_ID)), baselineEntitiesRequest);
     Assertions.assertTrue(baselineResponse.getBaselineEntityCount() > 0);
     Assertions.assertTrue(
         baselineResponse.getBaselineEntityList().get(0).getBaselineMetricSeriesCount() > 0);

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/baseline/BaselineServiceQueryParserTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/baseline/BaselineServiceQueryParserTest.java
@@ -1,5 +1,6 @@
 package org.hypertrace.gateway.service.baseline;
 
+import static org.hypertrace.core.grpcutils.context.RequestContext.forTenantId;
 import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.getResultSetChunk;
 
 import java.time.Instant;
@@ -77,7 +78,7 @@ public class BaselineServiceQueryParserTest {
                 "SERVICE.Latency",
                 "PERCENTILE_SERVICE.duration_[99]_PT30S"));
     BaselineRequestContext baselineRequestContext =
-        new BaselineRequestContext(TENANT_ID, Collections.EMPTY_MAP);
+        new BaselineRequestContext(forTenantId(TENANT_ID));
     BaselineTimeAggregation baselineTimeAggregation =
         BaselineTimeAggregation.newBuilder()
             .setAggregation(timeAggregation.getAggregation().getFunction())

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/AbstractServiceTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/AbstractServiceTest.java
@@ -32,8 +32,8 @@ import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadataFilter;
 import org.hypertrace.core.query.service.api.QueryRequest;
 import org.hypertrace.core.query.service.api.ResultSetChunk;
-import org.hypertrace.core.query.service.client.QueryServiceClient;
 import org.hypertrace.gateway.service.common.config.ScopeFilterConfigs;
+import org.hypertrace.gateway.service.common.util.QueryServiceClient;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -79,11 +79,7 @@ public abstract class AbstractServiceTest<
   }
 
   private static Reader readResourceFile(String fileName) {
-    InputStream in =
-        (new RequestContext(TENANT_ID, Map.of()))
-            .getClass()
-            .getClassLoader()
-            .getResourceAsStream(fileName);
+    InputStream in = RequestContext.class.getClassLoader().getResourceAsStream(fileName);
     return new BufferedReader(new InputStreamReader(in));
   }
 
@@ -92,8 +88,7 @@ public abstract class AbstractServiceTest<
 
     AttributeServiceClient attributesServiceClient = mock(AttributeServiceClient.class);
 
-    when(attributesServiceClient.findAttributes(
-            any(new HashMap<String, String>().getClass()), any(AttributeMetadataFilter.class)))
+    when(attributesServiceClient.findAttributes(any(Map.class), any(AttributeMetadataFilter.class)))
         .thenAnswer(
             (Answer<Iterator<AttributeMetadata>>)
                 invocation -> {
@@ -141,8 +136,7 @@ public abstract class AbstractServiceTest<
     // gateway service package
     // and use it's class loader to get the Resource.
     String folderName =
-        (new RequestContext(TENANT_ID, Map.of()))
-            .getClass()
+        RequestContext.class
             .getClassLoader()
             .getResource(String.format("%s/%s", GATEWAY_SERVICE_TEST_REQUESTS_DIR, suiteName))
             .getFile();
@@ -244,12 +238,11 @@ public abstract class AbstractServiceTest<
     Map<QueryRequest, ResultSetChunk> queryRequestResultSetChunkMap =
         readExpectedQueryServiceRequestAndResponse(fileName);
 
-    when(queryServiceClient.executeQuery(
-            any(QueryRequest.class), any(HashMap.class), any(Integer.class)))
+    when(queryServiceClient.executeQuery(any(RequestContext.class), any(QueryRequest.class)))
         .thenAnswer(
             (Answer<Iterator<ResultSetChunk>>)
                 invocation -> {
-                  QueryRequest queryRequest = (QueryRequest) invocation.getArguments()[0];
+                  QueryRequest queryRequest = (QueryRequest) invocation.getArguments()[1];
                   ResultSetChunk resultSetChunk = queryRequestResultSetChunkMap.get(queryRequest);
                   if (resultSetChunk
                       == null) { // This means this QueryRequest object is unexpected.

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/AttributeCacheKeyTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/AttributeCacheKeyTest.java
@@ -8,14 +8,12 @@ public class AttributeCacheKeyTest {
 
   @Test
   public void testAttributeCacheKey() {
-    RequestContext requestContext1 =
-        new RequestContext("test-tenant-1", Map.of("a1", "v1", "a2", "v2"));
-    RequestContext requestContext2 =
-        new RequestContext("test-tenant-2", Map.of("a1", "v1", "a2", "v2"));
+    RequestContext requestContext1 = buildContext("test-tenant-1", Map.of("a1", "v1", "a2", "v2"));
+    RequestContext requestContext2 = buildContext("test-tenant-2", Map.of("a1", "v1", "a2", "v2"));
     RequestContext requestContext3 =
-        new RequestContext("test-tenant-1", Map.of("a10", "v10", "a20", "v20"));
+        buildContext("test-tenant-1", Map.of("a10", "v10", "a20", "v20"));
     RequestContext requestContext4 =
-        new RequestContext("test-tenant-2", Map.of("a11", "v11", "a21", "v21"));
+        buildContext("test-tenant-2", Map.of("a11", "v11", "a21", "v21"));
 
     AttributeCacheKey<String> testCacheKey1 =
         new AttributeCacheKey<>(requestContext1, "testDataKey");
@@ -29,7 +27,8 @@ public class AttributeCacheKeyTest {
         new AttributeCacheKey<>(requestContext1, "testDataKey2");
 
     Assertions.assertEquals(testCacheKey1.getDataKey(), "testDataKey");
-    Assertions.assertEquals(testCacheKey1.getHeaders(), Map.of("a1", "v1", "a2", "v2"));
+    Assertions.assertEquals(
+        Map.of("x-tenant-id", "test-tenant-1", "a1", "v1", "a2", "v2"), testCacheKey1.getHeaders());
 
     Assertions.assertEquals(testCacheKey1, testCacheKey1);
     Assertions.assertEquals(testCacheKey1, testCacheKey3);
@@ -44,5 +43,12 @@ public class AttributeCacheKeyTest {
     Assertions.assertNotEquals(testCacheKey1.hashCode(), testCacheKey2.hashCode());
     Assertions.assertNotEquals(testCacheKey1.hashCode(), testCacheKey4.hashCode());
     Assertions.assertNotEquals(testCacheKey1.hashCode(), testCacheKey5.hashCode());
+  }
+
+  private RequestContext buildContext(String tenantId, Map<String, String> headers) {
+    org.hypertrace.core.grpcutils.context.RequestContext grpcContext =
+        org.hypertrace.core.grpcutils.context.RequestContext.forTenantId(tenantId);
+    headers.forEach(grpcContext::add);
+    return new RequestContext(grpcContext);
   }
 }

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/config/ScopeFilterConfigsTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/config/ScopeFilterConfigsTest.java
@@ -1,12 +1,12 @@
 package org.hypertrace.gateway.service.common.config;
 
+import static org.hypertrace.core.grpcutils.context.RequestContext.forTenantId;
 import static org.hypertrace.gateway.service.common.util.QueryExpressionUtil.buildAttributeExpression;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import java.util.Map;
 import java.util.Optional;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
 import org.hypertrace.core.attribute.service.v1.AttributeScope;
@@ -77,7 +77,7 @@ public class ScopeFilterConfigsTest {
                     .setRhs(createLiteralStringExpression("some-col-value")))
             .build();
 
-    RequestContext requestContext = new RequestContext("some-tenant-id", Map.of());
+    RequestContext requestContext = new RequestContext(forTenantId("some-tenant-id"));
     AttributeMetadataProvider attributeMetadataProvider = mock(AttributeMetadataProvider.class);
     when(attributeMetadataProvider.getAttributeMetadata(
             requestContext, AttributeScope.API_TRACE.name(), "apiBoundaryType"))
@@ -179,7 +179,7 @@ public class ScopeFilterConfigsTest {
                     .setRhs(createLiteralStringExpression("some-col-value")))
             .build();
 
-    RequestContext requestContext = new RequestContext("some-tenant-id", Map.of());
+    RequestContext requestContext = new RequestContext(forTenantId("some-tenant-id"));
     AttributeMetadataProvider attributeMetadataProvider = mock(AttributeMetadataProvider.class);
 
     // No change to filters since it will fail to parse the config because of the BOGUSOP unknown
@@ -211,7 +211,7 @@ public class ScopeFilterConfigsTest {
                     .setRhs(createLiteralStringExpression("some-col-value")))
             .build();
 
-    RequestContext requestContext = new RequestContext("some-tenant-id", Map.of());
+    RequestContext requestContext = new RequestContext(forTenantId("some-tenant-id"));
     AttributeMetadataProvider attributeMetadataProvider = mock(AttributeMetadataProvider.class);
 
     Assertions.assertEquals(

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/EntityDataServiceEntityFetcherTests.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/EntityDataServiceEntityFetcherTests.java
@@ -1,5 +1,6 @@
 package org.hypertrace.gateway.service.common.datafetcher;
 
+import static org.hypertrace.core.grpcutils.context.RequestContext.*;
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildOrderByExpression;
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.generateEQFilter;
 import static org.hypertrace.gateway.service.common.converters.EntityServiceAndGatewayServiceConverter.convertToEntityServiceExpression;
@@ -85,7 +86,6 @@ public class EntityDataServiceEntityFetcherTests {
     int limit = 10;
     int offset = 5;
     String tenantId = "TENANT_ID";
-    Map<String, String> requestHeaders = Map.of("x-tenant-id", tenantId);
     AttributeScope entityType = AttributeScope.API;
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
@@ -103,7 +103,7 @@ public class EntityDataServiceEntityFetcherTests {
             .build();
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            tenantId, startTime, endTime, entityType.name(), "API.startTime", requestHeaders);
+            forTenantId(tenantId), startTime, endTime, entityType.name(), "API.startTime");
 
     EntityQueryRequest expectedQueryRequest =
         EntityQueryRequest.newBuilder()
@@ -125,7 +125,8 @@ public class EntityDataServiceEntityFetcherTests {
     List<ResultSetChunk> resultSetChunks =
         List.of(getResultSetChunk(List.of("API.apiId"), new String[][] {{"apiId1"}, {"apiId2"}}));
 
-    when(entityQueryServiceClient.execute(eq(expectedQueryRequest), eq(requestHeaders)))
+    when(entityQueryServiceClient.execute(
+            eq(expectedQueryRequest), eq(entitiesRequestContext.getHeaders())))
         .thenReturn(resultSetChunks.iterator());
 
     assertEquals(
@@ -141,7 +142,6 @@ public class EntityDataServiceEntityFetcherTests {
     int limit = 0;
     int offset = 0;
     String tenantId = "TENANT_ID";
-    Map<String, String> requestHeaders = Map.of("x-tenant-id", tenantId);
     AttributeScope entityType = AttributeScope.API;
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
@@ -159,7 +159,7 @@ public class EntityDataServiceEntityFetcherTests {
             .build();
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            tenantId, startTime, endTime, entityType.name(), "API.startTime", requestHeaders);
+            forTenantId(tenantId), startTime, endTime, entityType.name(), "API.startTime");
 
     EntityQueryRequest expectedQueryRequest =
         EntityQueryRequest.newBuilder()
@@ -179,7 +179,8 @@ public class EntityDataServiceEntityFetcherTests {
     List<ResultSetChunk> resultSetChunks =
         List.of(getResultSetChunk(List.of("API.apiId"), new String[][] {{"apiId1"}, {"apiId2"}}));
 
-    when(entityQueryServiceClient.execute(eq(expectedQueryRequest), eq(requestHeaders)))
+    when(entityQueryServiceClient.execute(
+            eq(expectedQueryRequest), eq(entitiesRequestContext.getHeaders())))
         .thenReturn(resultSetChunks.iterator());
 
     assertEquals(
@@ -193,7 +194,7 @@ public class EntityDataServiceEntityFetcherTests {
         UnsupportedOperationException.class,
         () -> {
           entityDataServiceEntityFetcher.getTimeAggregatedMetrics(
-              new EntitiesRequestContext(TENANT_ID, 0, 1, "API", "API.startTime", Map.of()),
+              new EntitiesRequestContext(forTenantId(TENANT_ID), 0, 1, "API", "API.startTime"),
               EntitiesRequest.newBuilder().build());
         });
   }
@@ -208,7 +209,6 @@ public class EntityDataServiceEntityFetcherTests {
       int limit = 10;
       int offset = 5;
       String tenantId = "TENANT_ID";
-      Map<String, String> requestHeaders = Map.of("x-tenant-id", tenantId);
       AttributeScope entityType = AttributeScope.API;
       EntitiesRequest entitiesRequest =
           EntitiesRequest.newBuilder()
@@ -226,7 +226,7 @@ public class EntityDataServiceEntityFetcherTests {
               .build();
       EntitiesRequestContext entitiesRequestContext =
           new EntitiesRequestContext(
-              tenantId, startTime, endTime, entityType.name(), "API.startTime", requestHeaders);
+              forTenantId(tenantId), startTime, endTime, entityType.name(), "API.startTime");
 
       TotalEntitiesRequest expectedQueryRequest =
           TotalEntitiesRequest.newBuilder()
@@ -234,7 +234,8 @@ public class EntityDataServiceEntityFetcherTests {
               .setFilter(convertToEntityServiceFilter(entitiesRequest.getFilter()))
               .build();
 
-      when(entityQueryServiceClient.total(eq(expectedQueryRequest), eq(requestHeaders)))
+      when(entityQueryServiceClient.total(
+              eq(expectedQueryRequest), eq(entitiesRequestContext.getHeaders())))
           .thenReturn(TotalEntitiesResponse.newBuilder().setTotal(100L).build());
 
       assertEquals(
@@ -251,7 +252,7 @@ public class EntityDataServiceEntityFetcherTests {
       long endTime = 10L;
       int limit = 0;
       int offset = 0;
-      RequestContext requestContext = RequestContext.forTenantId(TENANT_ID);
+      RequestContext requestContext = forTenantId(TENANT_ID);
       AttributeScope entityType = AttributeScope.API;
       EntitiesRequest entitiesRequest =
           EntitiesRequest.newBuilder()
@@ -265,12 +266,7 @@ public class EntityDataServiceEntityFetcherTests {
               .build();
       EntitiesRequestContext entitiesRequestContext =
           new EntitiesRequestContext(
-              requestContext.getTenantId().get(),
-              startTime,
-              endTime,
-              entityType.name(),
-              "API.startTime",
-              requestContext.getRequestHeaders());
+              requestContext, startTime, endTime, entityType.name(), "API.startTime");
 
       EntityQueryRequest expectedQueryRequest =
           EntityQueryRequest.newBuilder()
@@ -321,7 +317,7 @@ public class EntityDataServiceEntityFetcherTests {
       long endTime = 10L;
       int limit = 0;
       int offset = 0;
-      RequestContext requestContext = RequestContext.forTenantId(TENANT_ID);
+      RequestContext requestContext = forTenantId(TENANT_ID);
       AttributeScope entityType = AttributeScope.API;
       EntitiesRequest entitiesRequest =
           EntitiesRequest.newBuilder()
@@ -335,12 +331,7 @@ public class EntityDataServiceEntityFetcherTests {
               .build();
       EntitiesRequestContext entitiesRequestContext =
           new EntitiesRequestContext(
-              requestContext.getTenantId().get(),
-              startTime,
-              endTime,
-              entityType.name(),
-              "API.startTime",
-              requestContext.getRequestHeaders());
+              requestContext, startTime, endTime, entityType.name(), "API.startTime");
 
       EntityQueryRequest expectedQueryRequest =
           EntityQueryRequest.newBuilder()

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/EntityInteractionsFetcherTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/EntityInteractionsFetcherTest.java
@@ -1,5 +1,6 @@
 package org.hypertrace.gateway.service.common.datafetcher;
 
+import static org.hypertrace.core.grpcutils.context.RequestContext.forTenantId;
 import static org.hypertrace.gateway.service.common.converters.QueryRequestUtil.createBetweenTimesFilter;
 import static org.hypertrace.gateway.service.common.converters.QueryRequestUtil.createFilter;
 import static org.hypertrace.gateway.service.common.converters.QueryRequestUtil.createStringArrayLiteralExpression;
@@ -17,7 +18,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -115,7 +115,7 @@ public class EntityInteractionsFetcherTest extends AbstractGatewayServiceTest {
         .thenReturn(Optional.of(AttributeMetadata.newBuilder().setId("dummy").build()));
 
     EntityInteractionsFetcher aggregator =
-        new EntityInteractionsFetcher(null, 500, attributeMetadataProvider, queryExecutor);
+        new EntityInteractionsFetcher(null, attributeMetadataProvider, queryExecutor);
     Map<String, QueryRequest> queryRequests =
         aggregator.buildQueryRequests(
             request.getStartTimeMillis(),
@@ -224,7 +224,7 @@ public class EntityInteractionsFetcherTest extends AbstractGatewayServiceTest {
         .thenReturn(Optional.of(AttributeMetadata.newBuilder().setId("dummy").build()));
 
     EntityInteractionsFetcher aggregator =
-        new EntityInteractionsFetcher(null, 500, attributeMetadataProvider, queryExecutor);
+        new EntityInteractionsFetcher(null, attributeMetadataProvider, queryExecutor);
     Map<String, QueryRequest> queryRequests =
         aggregator.buildQueryRequests(
             request.getStartTimeMillis(),
@@ -288,7 +288,7 @@ public class EntityInteractionsFetcherTest extends AbstractGatewayServiceTest {
             Optional.of(AttributeMetadata.newBuilder().setId("INTERACTION.startTime").build()));
 
     EntityInteractionsFetcher aggregator =
-        new EntityInteractionsFetcher(null, 500, attributeMetadataProvider, queryExecutor);
+        new EntityInteractionsFetcher(null, attributeMetadataProvider, queryExecutor);
     Map<String, QueryRequest> queryRequests =
         aggregator.buildQueryRequests(
             request.getStartTimeMillis(),
@@ -407,7 +407,7 @@ public class EntityInteractionsFetcherTest extends AbstractGatewayServiceTest {
             Optional.of(AttributeMetadata.newBuilder().setId("INTERACTION.startTime").build()));
 
     EntityInteractionsFetcher aggregator =
-        new EntityInteractionsFetcher(null, 500, attributeMetadataProvider, queryExecutor);
+        new EntityInteractionsFetcher(null, attributeMetadataProvider, queryExecutor);
     LinkedHashSet<EntityKey> entityKeys = new LinkedHashSet<>();
     entityKeys.add(EntityKey.of("test_name1", "test_type1"));
     entityKeys.add(EntityKey.of("test_name2", "test_type2"));
@@ -507,7 +507,7 @@ public class EntityInteractionsFetcherTest extends AbstractGatewayServiceTest {
         .thenReturn(Optional.of(AttributeMetadata.newBuilder().setId("dummy").build()));
 
     EntityInteractionsFetcher aggregator =
-        new EntityInteractionsFetcher(null, 500, attributeMetadataProvider, queryExecutor);
+        new EntityInteractionsFetcher(null, attributeMetadataProvider, queryExecutor);
     Map<String, QueryRequest> queryRequests =
         aggregator.buildQueryRequests(
             request.getStartTimeMillis(),
@@ -581,12 +581,12 @@ public class EntityInteractionsFetcherTest extends AbstractGatewayServiceTest {
                 Mockito.eq("startTime")))
         .thenReturn(Optional.of(AttributeMetadata.newBuilder().setFqn("dummy").build()));
     EntityInteractionsFetcher aggregator =
-        new EntityInteractionsFetcher(null, 500, attributeMetadataProvider, queryExecutor);
+        new EntityInteractionsFetcher(null, attributeMetadataProvider, queryExecutor);
 
     for (EntitiesRequest request : getInvalidRequests()) {
       try {
         aggregator.populateEntityInteractions(
-            new RequestContext(TENANT_ID, new HashMap<>()), request, Collections.emptyMap());
+            new RequestContext(forTenantId(TENANT_ID)), request, Collections.emptyMap());
         fail("Expected the request to fail. Request: " + request);
       } catch (IllegalArgumentException ignore) {
         // Ignore.

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/datafetcher/QueryServiceEntityFetcherTests.java
@@ -1,5 +1,7 @@
 package org.hypertrace.gateway.service.common.datafetcher;
 
+import static org.hypertrace.core.grpcutils.context.RequestContext.forTenantId;
+import static org.hypertrace.core.query.service.client.QueryServiceClient.DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT;
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildAggregateExpression;
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildExpression;
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildOrderByExpression;
@@ -33,12 +35,12 @@ import org.hypertrace.core.attribute.service.v1.AttributeScope;
 import org.hypertrace.core.query.service.api.Operator;
 import org.hypertrace.core.query.service.api.QueryRequest;
 import org.hypertrace.core.query.service.api.ResultSetChunk;
-import org.hypertrace.core.query.service.client.QueryServiceClient;
 import org.hypertrace.gateway.service.common.AttributeMetadataProvider;
 import org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils;
 import org.hypertrace.gateway.service.common.RequestContext;
 import org.hypertrace.gateway.service.common.converters.QueryAndGatewayDtoConverter;
 import org.hypertrace.gateway.service.common.converters.QueryRequestUtil;
+import org.hypertrace.gateway.service.common.util.QueryServiceClient;
 import org.hypertrace.gateway.service.entity.EntitiesRequestContext;
 import org.hypertrace.gateway.service.entity.EntityKey;
 import org.hypertrace.gateway.service.entity.config.EntityIdColumnsConfigs;
@@ -88,7 +90,7 @@ public class QueryServiceEntityFetcherTests {
 
     queryServiceEntityFetcher =
         new QueryServiceEntityFetcher(
-            queryServiceClient, 500, attributeMetadataProvider, entityIdColumnsConfigs);
+            queryServiceClient, attributeMetadataProvider, entityIdColumnsConfigs);
   }
 
   @Test
@@ -100,7 +102,6 @@ public class QueryServiceEntityFetcherTests {
     int limit = 10;
     int offset = 5;
     String tenantId = "TENANT_ID";
-    Map<String, String> requestHeaders = Map.of("x-tenant-id", tenantId);
     AttributeScope entityType = AttributeScope.API;
 
     TimeAggregation timeAggregation1 =
@@ -141,7 +142,7 @@ public class QueryServiceEntityFetcherTests {
 
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            tenantId, startTime, endTime, entityType.name(), "API.startTime", requestHeaders);
+            forTenantId(tenantId), startTime, endTime, entityType.name(), "API.startTime");
 
     QueryRequest expectedQueryRequest =
         QueryRequest.newBuilder()
@@ -176,7 +177,7 @@ public class QueryServiceEntityFetcherTests {
                   {"apiId2", "20000", "34", "68"}
                 }));
 
-    when(queryServiceClient.executeQuery(eq(expectedQueryRequest), eq(requestHeaders), eq(500)))
+    when(queryServiceClient.executeQuery(eq(entitiesRequestContext), eq(expectedQueryRequest)))
         .thenReturn(resultSetChunks.iterator());
 
     EntityFetcherResponse response =
@@ -261,7 +262,6 @@ public class QueryServiceEntityFetcherTests {
     int limit = 10;
     int offset = 5;
     String tenantId = "TENANT_ID";
-    Map<String, String> requestHeaders = Map.of("x-tenant-id", tenantId);
     AttributeScope entityType = AttributeScope.API;
 
     TimeAggregation timeAggregation =
@@ -300,7 +300,7 @@ public class QueryServiceEntityFetcherTests {
 
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            tenantId, startTime, endTime, entityType.name(), "API.startTime", requestHeaders);
+            forTenantId(tenantId), startTime, endTime, entityType.name(), "API.startTime");
 
     QueryRequest expectedQueryRequest =
         QueryRequest.newBuilder()
@@ -332,7 +332,7 @@ public class QueryServiceEntityFetcherTests {
                   {"apiId2", "20000", "34"}
                 }));
 
-    when(queryServiceClient.executeQuery(eq(expectedQueryRequest), eq(requestHeaders), eq(500)))
+    when(queryServiceClient.executeQuery(eq(entitiesRequestContext), eq(expectedQueryRequest)))
         .thenReturn(resultSetChunks.iterator());
 
     EntityFetcherResponse response =
@@ -394,7 +394,6 @@ public class QueryServiceEntityFetcherTests {
     int limit = 10;
     int offset = 5;
     String tenantId = "TENANT_ID";
-    Map<String, String> requestHeaders = Map.of("x-tenant-id", tenantId);
     AttributeScope entityType = AttributeScope.API;
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
@@ -418,7 +417,7 @@ public class QueryServiceEntityFetcherTests {
             .build();
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            tenantId, startTime, endTime, entityType.name(), "API.startTime", requestHeaders);
+            forTenantId(tenantId), startTime, endTime, entityType.name(), "API.startTime");
 
     QueryRequest expectedQueryRequest =
         QueryRequest.newBuilder()
@@ -435,7 +434,7 @@ public class QueryServiceEntityFetcherTests {
             .addGroupBy(createAttributeExpression(API_ID_ATTR))
             .addGroupBy(createAttributeExpression(API_NAME_ATTR))
             .setOffset(offset)
-            .setLimit(QueryServiceClient.DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT)
+            .setLimit(DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT)
             .addAllOrderBy(
                 QueryAndGatewayDtoConverter.convertToQueryOrderByExpressions(orderByExpressions))
             .build();
@@ -446,7 +445,7 @@ public class QueryServiceEntityFetcherTests {
                 List.of("API.id", "API.name", "Sum_numCalls"),
                 new String[][] {{"apiId1", "api 1", "3"}, {"apiId2", "api 2", "5"}}));
 
-    when(queryServiceClient.executeQuery(eq(expectedQueryRequest), eq(requestHeaders), eq(500)))
+    when(queryServiceClient.executeQuery(eq(entitiesRequestContext), eq(expectedQueryRequest)))
         .thenReturn(resultSetChunks.iterator());
 
     EntityFetcherResponse response =
@@ -482,7 +481,6 @@ public class QueryServiceEntityFetcherTests {
     int limit = 10;
     int offset = 5;
     String tenantId = "TENANT_ID";
-    Map<String, String> requestHeaders = Map.of("x-tenant-id", tenantId);
     AttributeScope entityType = AttributeScope.API;
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
@@ -505,7 +503,7 @@ public class QueryServiceEntityFetcherTests {
             .build();
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            tenantId, startTime, endTime, entityType.name(), "API.startTime", requestHeaders);
+            forTenantId(tenantId), startTime, endTime, entityType.name(), "API.startTime");
 
     QueryRequest expectedQueryRequest =
         QueryRequest.newBuilder()
@@ -528,7 +526,7 @@ public class QueryServiceEntityFetcherTests {
     List<ResultSetChunk> resultSetChunks =
         List.of(getResultSetChunk(List.of("API.apiId"), new String[][] {{"apiId1"}, {"apiId2"}}));
 
-    when(queryServiceClient.executeQuery(eq(expectedQueryRequest), eq(requestHeaders), eq(500)))
+    when(queryServiceClient.executeQuery(eq(entitiesRequestContext), eq(expectedQueryRequest)))
         .thenReturn(resultSetChunks.iterator());
 
     assertEquals(
@@ -543,7 +541,6 @@ public class QueryServiceEntityFetcherTests {
     int limit = 0;
     int offset = 0;
     String tenantId = "TENANT_ID";
-    Map<String, String> requestHeaders = Map.of("x-tenant-id", tenantId);
     AttributeScope entityType = AttributeScope.API;
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
@@ -566,7 +563,7 @@ public class QueryServiceEntityFetcherTests {
             .build();
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            tenantId, startTime, endTime, entityType.name(), "API.startTime", requestHeaders);
+            forTenantId(tenantId), startTime, endTime, entityType.name(), "API.startTime");
 
     QueryRequest expectedQueryRequest =
         QueryRequest.newBuilder()
@@ -580,7 +577,7 @@ public class QueryServiceEntityFetcherTests {
                     endTime,
                     createStringFilter(API_DISCOVERY_STATE_ATTR, Operator.EQ, "DISCOVERED")))
             .addGroupBy(createAttributeExpression(API_ID_ATTR))
-            .setLimit(QueryServiceClient.DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT)
+            .setLimit(DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT)
             .addAllOrderBy(
                 QueryAndGatewayDtoConverter.convertToQueryOrderByExpressions(orderByExpressions))
             .build();
@@ -588,7 +585,7 @@ public class QueryServiceEntityFetcherTests {
     List<ResultSetChunk> resultSetChunks =
         List.of(getResultSetChunk(List.of("API.apiId"), new String[][] {{"apiId1"}, {"apiId2"}}));
 
-    when(queryServiceClient.executeQuery(eq(expectedQueryRequest), eq(requestHeaders), eq(500)))
+    when(queryServiceClient.executeQuery(eq(entitiesRequestContext), eq(expectedQueryRequest)))
         .thenReturn(resultSetChunks.iterator());
 
     assertEquals(
@@ -603,7 +600,6 @@ public class QueryServiceEntityFetcherTests {
     int offset = 0;
     String tenantId = "TENANT_ID";
     String space = "test-space";
-    Map<String, String> requestHeaders = Map.of("x-tenant-id", tenantId);
     AttributeScope entityType = AttributeScope.API;
     EntitiesRequest entitiesRequest =
         EntitiesRequest.newBuilder()
@@ -617,7 +613,7 @@ public class QueryServiceEntityFetcherTests {
             .build();
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            tenantId, startTime, endTime, entityType.name(), "API.startTime", requestHeaders);
+            forTenantId(tenantId), startTime, endTime, entityType.name(), "API.startTime");
 
     QueryRequest expectedQueryRequest =
         QueryRequest.newBuilder()
@@ -634,7 +630,7 @@ public class QueryServiceEntityFetcherTests {
             .addGroupBy(createAttributeExpression(API_ID_ATTR))
             .addGroupBy(createAttributeExpression(API_NAME_ATTR))
             .setOffset(offset)
-            .setLimit(QueryServiceClient.DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT)
+            .setLimit(DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT)
             .build();
 
     List<ResultSetChunk> resultSetChunks =
@@ -653,7 +649,7 @@ public class QueryServiceEntityFetcherTests {
 
     EntityFetcherResponse expectedEntityFetcherResponse =
         new EntityFetcherResponse(expectedEntityKeyBuilderResponseMap);
-    when(queryServiceClient.executeQuery(eq(expectedQueryRequest), eq(requestHeaders), eq(500)))
+    when(queryServiceClient.executeQuery(eq(entitiesRequestContext), eq(expectedQueryRequest)))
         .thenReturn(resultSetChunks.iterator());
 
     compareEntityFetcherResponses(
@@ -671,7 +667,6 @@ public class QueryServiceEntityFetcherTests {
       int limit = 10;
       int offset = 5;
       String tenantId = "TENANT_ID";
-      Map<String, String> requestHeaders = Map.of("x-tenant-id", tenantId);
       AttributeScope entityType = AttributeScope.API;
       EntitiesRequest entitiesRequest =
           EntitiesRequest.newBuilder()
@@ -694,7 +689,7 @@ public class QueryServiceEntityFetcherTests {
               .build();
       EntitiesRequestContext entitiesRequestContext =
           new EntitiesRequestContext(
-              tenantId, startTime, endTime, entityType.name(), "API.startTime", requestHeaders);
+              forTenantId(tenantId), startTime, endTime, entityType.name(), "API.startTime");
 
       QueryRequest expectedQueryRequest =
           QueryRequest.newBuilder()
@@ -712,7 +707,7 @@ public class QueryServiceEntityFetcherTests {
       List<ResultSetChunk> resultSetChunks =
           List.of(getResultSetChunk(List.of("DISTINCCOUNT"), new String[][] {{"100"}}));
 
-      when(queryServiceClient.executeQuery(eq(expectedQueryRequest), eq(requestHeaders), eq(500)))
+      when(queryServiceClient.executeQuery(eq(entitiesRequestContext), eq(expectedQueryRequest)))
           .thenReturn(resultSetChunks.iterator());
 
       assertEquals(

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/transformer/RequestPreProcessorTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/common/transformer/RequestPreProcessorTest.java
@@ -1,12 +1,12 @@
 package org.hypertrace.gateway.service.common.transformer;
 
+import static org.hypertrace.core.grpcutils.context.RequestContext.forTenantId;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.io.File;
-import java.util.Map;
 import java.util.Optional;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
 import org.hypertrace.core.attribute.service.v1.AttributeScope;
@@ -48,7 +48,7 @@ public class RequestPreProcessorTest {
     long startTime = endTime - 1000L;
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            TEST_TENANT_ID, startTime, endTime, "SERVICE", "SERVICE.startTime", Map.of());
+            forTenantId(TEST_TENANT_ID), startTime, endTime, "SERVICE", "SERVICE.startTime");
     mockAttributeMetadata(entitiesRequestContext, AttributeScope.SERVICE.name(), "id");
     mockAttributeMetadata(entitiesRequestContext, AttributeScope.SERVICE.name(), "name");
     mockAttributeMetadata(entitiesRequestContext, AttributeScope.SERVICE.name(), "startTime");
@@ -118,7 +118,7 @@ public class RequestPreProcessorTest {
   public void testApiTracesRequestScopeFilterConfigsAdded() {
     long endTime = System.currentTimeMillis();
     long startTime = endTime - 1000L;
-    RequestContext requestContext = new RequestContext(TEST_TENANT_ID, Map.of());
+    RequestContext requestContext = new RequestContext(forTenantId(TEST_TENANT_ID));
     mockAttributeMetadata(requestContext, AttributeScope.API_TRACE.name(), "apiBoundaryType");
     mockAttributeMetadata(requestContext, AttributeScope.API_TRACE.name(), "apiId");
 

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/EntityServiceInteractionRequestTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/EntityServiceInteractionRequestTest.java
@@ -1,5 +1,7 @@
 package org.hypertrace.gateway.service.entity;
 
+import static org.hypertrace.core.grpcutils.context.RequestContext.forTenantId;
+import static org.hypertrace.core.query.service.client.QueryServiceClient.DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT;
 import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.createQsAggregationExpression;
 import static org.hypertrace.gateway.service.common.QueryServiceRequestAndResponseUtils.createQsDefaultRequestFilter;
 import static org.hypertrace.gateway.service.common.converters.QueryRequestUtil.createAttributeExpression;
@@ -35,13 +37,13 @@ import org.hypertrace.core.query.service.api.QueryRequest;
 import org.hypertrace.core.query.service.api.ResultSetChunk;
 import org.hypertrace.core.query.service.api.ResultSetMetadata;
 import org.hypertrace.core.query.service.api.Row;
-import org.hypertrace.core.query.service.client.QueryServiceClient;
 import org.hypertrace.entity.query.service.client.EntityQueryServiceClient;
 import org.hypertrace.gateway.service.AbstractGatewayServiceTest;
 import org.hypertrace.gateway.service.common.AttributeMetadataProvider;
 import org.hypertrace.gateway.service.common.RequestContext;
 import org.hypertrace.gateway.service.common.config.ScopeFilterConfigs;
 import org.hypertrace.gateway.service.common.converters.QueryRequestUtil;
+import org.hypertrace.gateway.service.common.util.QueryServiceClient;
 import org.hypertrace.gateway.service.entity.config.EntityIdColumnsConfigs;
 import org.hypertrace.gateway.service.entity.config.LogConfig;
 import org.hypertrace.gateway.service.executor.QueryExecutorConfig;
@@ -348,10 +350,10 @@ public class EntityServiceInteractionRequestTest extends AbstractGatewayServiceT
             .addSelection(createQsAggregationExpression("COUNT", "SERVICE.id"))
             .setFilter(queryServiceFilter)
             .addGroupBy(createAttributeExpression("SERVICE.id"))
-            .setLimit(QueryServiceClient.DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT)
+            .setLimit(DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT)
             .build();
 
-    when(queryServiceClient.executeQuery(eq(expectedQueryRequest), any(), Mockito.anyInt()))
+    when(queryServiceClient.executeQuery(any(RequestContext.class), eq(expectedQueryRequest)))
         .thenReturn(
             List.of(
                     ResultSetChunk.newBuilder()
@@ -396,10 +398,10 @@ public class EntityServiceInteractionRequestTest extends AbstractGatewayServiceT
             .setFilter(interactionQueryFilter)
             .addGroupBy(createAttributeExpression("INTERACTION.toServiceId"))
             .addGroupBy(createAttributeExpression("INTERACTION.fromServiceId"))
-            .setLimit(QueryServiceClient.DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT)
+            .setLimit(DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT)
             .build();
 
-    when(queryServiceClient.executeQuery(eq(expectedQueryRequest), any(), Mockito.anyInt()))
+    when(queryServiceClient.executeQuery(any(RequestContext.class), eq(expectedQueryRequest)))
         .thenReturn(
             List.of(
                     ResultSetChunk.newBuilder()
@@ -447,10 +449,10 @@ public class EntityServiceInteractionRequestTest extends AbstractGatewayServiceT
             .setFilter(interactionQueryFilter)
             .addGroupBy(createAttributeExpression("INTERACTION.fromServiceId"))
             .addGroupBy(createAttributeExpression("INTERACTION.toServiceId"))
-            .setLimit(QueryServiceClient.DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT)
+            .setLimit(DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT)
             .build();
 
-    when(queryServiceClient.executeQuery(eq(expectedQueryRequest), any(), Mockito.anyInt()))
+    when(queryServiceClient.executeQuery(any(RequestContext.class), eq(expectedQueryRequest)))
         .thenReturn(
             List.of(
                     ResultSetChunk.newBuilder()
@@ -498,10 +500,10 @@ public class EntityServiceInteractionRequestTest extends AbstractGatewayServiceT
             .setFilter(interactionQueryFilter)
             .addGroupBy(createAttributeExpression("INTERACTION.fromServiceId"))
             .addGroupBy(createAttributeExpression("INTERACTION.toBackendId"))
-            .setLimit(QueryServiceClient.DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT)
+            .setLimit(DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT)
             .build();
 
-    when(queryServiceClient.executeQuery(eq(expectedQueryRequest), any(), Mockito.anyInt()))
+    when(queryServiceClient.executeQuery(any(RequestContext.class), eq(expectedQueryRequest)))
         .thenReturn(
             List.of(
                     ResultSetChunk.newBuilder()
@@ -620,14 +622,14 @@ public class EntityServiceInteractionRequestTest extends AbstractGatewayServiceT
     EntityService entityService =
         new EntityService(
             queryServiceClient,
-            500,
             entityQueryServiceClient,
             attributeMetadataProvider,
             entityIdColumnsConfigs,
             scopeFilterConfigs,
             logConfig,
             queryExecutor);
-    EntitiesResponse response = entityService.getEntities(TENANT_ID, request, Map.of());
+    EntitiesResponse response =
+        entityService.getEntities(new RequestContext(forTenantId(TENANT_ID)), request);
 
     // validate we have one incoming edge, and two outgoing edge
     assertNotNull(response);

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionContextTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionContextTest.java
@@ -1,5 +1,6 @@
 package org.hypertrace.gateway.service.entity.query;
 
+import static org.hypertrace.core.grpcutils.context.RequestContext.forTenantId;
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildExpression;
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.generateEQFilter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -65,7 +66,7 @@ class ExecutionContextTest {
                 .thenReturn(Optional.of(attribute)));
 
     entitiesRequestContext =
-        new EntitiesRequestContext(TENANT_ID, 0, 100, "API", "API.startTime", new HashMap<>());
+        new EntitiesRequestContext(forTenantId(TENANT_ID), 0, 100, "API", "API.startTime");
   }
 
   @Test

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilderTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/ExecutionTreeBuilderTest.java
@@ -1,5 +1,6 @@
 package org.hypertrace.gateway.service.entity.query;
 
+import static org.hypertrace.core.grpcutils.context.RequestContext.forTenantId;
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildAggregateExpression;
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildExpression;
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildOrderByExpression;
@@ -174,12 +175,11 @@ public class ExecutionTreeBuilderTest {
   private EntityExecutionContext getExecutionContext(EntitiesRequest entitiesRequest) {
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            TENANT_ID,
+            forTenantId(TENANT_ID),
             entitiesRequest.getStartTimeMillis(),
             entitiesRequest.getEndTimeMillis(),
             "API",
-            "API.startTime",
-            new HashMap<>());
+            "API.startTime");
     return new EntityExecutionContext(
         attributeMetadataProvider, entityIdColumnsConfigs, entitiesRequestContext, entitiesRequest);
   }
@@ -499,7 +499,7 @@ public class ExecutionTreeBuilderTest {
               .setOffset(20)
               .build();
       EntitiesRequestContext entitiesRequestContext =
-          new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", "API.startTime", new HashMap<>());
+          new EntitiesRequestContext(forTenantId(TENANT_ID), 0L, 10L, "API", "API.startTime");
       EntityExecutionContext executionContext =
           new EntityExecutionContext(
               attributeMetadataProvider,
@@ -538,7 +538,7 @@ public class ExecutionTreeBuilderTest {
               .build();
       EntitiesRequestContext entitiesRequestContext =
           new EntitiesRequestContext(
-              TENANT_ID, startTime, endTime, "API", "API.startTime", new HashMap<>());
+              forTenantId(TENANT_ID), startTime, endTime, "API", "API.startTime");
       EntityExecutionContext executionContext =
           new EntityExecutionContext(
               attributeMetadataProvider,
@@ -575,7 +575,7 @@ public class ExecutionTreeBuilderTest {
             .setOffset(20)
             .build();
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", "API.startTime", new HashMap<>());
+        new EntitiesRequestContext(forTenantId(TENANT_ID), 0L, 10L, "API", "API.startTime");
     EntityExecutionContext executionContext =
         new EntityExecutionContext(
             attributeMetadataProvider,
@@ -605,7 +605,7 @@ public class ExecutionTreeBuilderTest {
             .setOffset(0)
             .build();
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", "API.startTime", new HashMap<>());
+        new EntitiesRequestContext(forTenantId(TENANT_ID), 0L, 10L, "API", "API.startTime");
     EntityExecutionContext executionContext =
         new EntityExecutionContext(
             attributeMetadataProvider,
@@ -657,7 +657,7 @@ public class ExecutionTreeBuilderTest {
             .setOffset(0)
             .build();
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", "API.startTime", new HashMap<>());
+        new EntitiesRequestContext(forTenantId(TENANT_ID), 0L, 10L, "API", "API.startTime");
     EntityExecutionContext executionContext =
         new EntityExecutionContext(
             attributeMetadataProvider,
@@ -710,7 +710,7 @@ public class ExecutionTreeBuilderTest {
             .setOffset(10)
             .build();
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", "API.startTime", new HashMap<>());
+        new EntitiesRequestContext(forTenantId(TENANT_ID), 0L, 10L, "API", "API.startTime");
     EntityExecutionContext executionContext =
         new EntityExecutionContext(
             attributeMetadataProvider,
@@ -762,7 +762,7 @@ public class ExecutionTreeBuilderTest {
             .setOffset(10)
             .build();
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", "API.startTime", new HashMap<>());
+        new EntitiesRequestContext(forTenantId(TENANT_ID), 0L, 10L, "API", "API.startTime");
     EntityExecutionContext executionContext =
         new EntityExecutionContext(
             attributeMetadataProvider,
@@ -810,12 +810,11 @@ public class ExecutionTreeBuilderTest {
             .build();
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            TENANT_ID,
+            forTenantId(TENANT_ID),
             entitiesRequest.getStartTimeMillis(),
             entitiesRequest.getEndTimeMillis(),
             "API",
-            "API.startTime",
-            new HashMap<>());
+            "API.startTime");
     EntityExecutionContext executionContext =
         new EntityExecutionContext(
             attributeMetadataProvider,
@@ -858,7 +857,7 @@ public class ExecutionTreeBuilderTest {
                     API_NUM_CALLS_ATTR, FunctionType.SUM, "SUM_numCalls", List.of()))
             .build();
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", "API.startTime", new HashMap<>());
+        new EntitiesRequestContext(forTenantId(TENANT_ID), 0L, 10L, "API", "API.startTime");
     EntityExecutionContext executionContext =
         new EntityExecutionContext(
             attributeMetadataProvider,
@@ -899,7 +898,7 @@ public class ExecutionTreeBuilderTest {
             .setIncludeNonLiveEntities(true)
             .build();
     EntitiesRequestContext entitiesRequestContext =
-        new EntitiesRequestContext(TENANT_ID, 0L, 10L, "API", "API.startTime", new HashMap<>());
+        new EntitiesRequestContext(forTenantId(TENANT_ID), 0L, 10L, "API", "API.startTime");
     EntityExecutionContext executionContext =
         new EntityExecutionContext(
             attributeMetadataProvider,
@@ -941,12 +940,11 @@ public class ExecutionTreeBuilderTest {
             .build();
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            TENANT_ID,
+            forTenantId(TENANT_ID),
             entitiesRequest.getStartTimeMillis(),
             entitiesRequest.getEndTimeMillis(),
             "API",
-            "API.startTime",
-            new HashMap<>());
+            "API.startTime");
     EntityExecutionContext executionContext =
         new EntityExecutionContext(
             attributeMetadataProvider,
@@ -1002,12 +1000,11 @@ public class ExecutionTreeBuilderTest {
             .build();
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            TENANT_ID,
+            forTenantId(TENANT_ID),
             entitiesRequest.getStartTimeMillis(),
             entitiesRequest.getEndTimeMillis(),
             "API",
-            "API.startTime",
-            new HashMap<>());
+            "API.startTime");
     EntityExecutionContext executionContext =
         new EntityExecutionContext(
             attributeMetadataProvider,
@@ -1042,12 +1039,11 @@ public class ExecutionTreeBuilderTest {
             .build();
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            TENANT_ID,
+            forTenantId(TENANT_ID),
             entitiesRequest.getStartTimeMillis(),
             entitiesRequest.getEndTimeMillis(),
             "API",
-            "API.startTime",
-            new HashMap<>());
+            "API.startTime");
     EntityExecutionContext executionContext =
         new EntityExecutionContext(
             attributeMetadataProvider,
@@ -1082,12 +1078,11 @@ public class ExecutionTreeBuilderTest {
             .build();
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            TENANT_ID,
+            forTenantId(TENANT_ID),
             entitiesRequest.getStartTimeMillis(),
             entitiesRequest.getEndTimeMillis(),
             "API",
-            "API.startTime",
-            new HashMap<>());
+            "API.startTime");
     EntityExecutionContext executionContext =
         new EntityExecutionContext(
             attributeMetadataProvider,
@@ -1114,12 +1109,11 @@ public class ExecutionTreeBuilderTest {
             .build();
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            TENANT_ID,
+            forTenantId(TENANT_ID),
             entitiesRequest.getStartTimeMillis(),
             entitiesRequest.getEndTimeMillis(),
             "API",
-            "API.startTime",
-            new HashMap<>());
+            "API.startTime");
     EntityExecutionContext executionContext =
         new EntityExecutionContext(
             attributeMetadataProvider,

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitorTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/entity/query/visitor/ExecutionVisitorTest.java
@@ -1,5 +1,6 @@
 package org.hypertrace.gateway.service.entity.query.visitor;
 
+import static org.hypertrace.core.grpcutils.context.RequestContext.forTenantId;
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildAggregateExpression;
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildExpression;
 import static org.hypertrace.gateway.service.common.EntitiesRequestAndResponseUtils.buildOrderByExpression;
@@ -387,7 +388,6 @@ public class ExecutionVisitorTest {
     long startTime = 0;
     long endTime = 10;
     String tenantId = "TENANT_ID";
-    Map<String, String> requestHeaders = Map.of("x-tenant-id", tenantId);
     AttributeScope entityType = AttributeScope.API;
     Expression selectionExpression = buildExpression(API_NAME_ATTR);
     EntitiesRequest entitiesRequest =
@@ -403,7 +403,7 @@ public class ExecutionVisitorTest {
             .build();
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            tenantId, startTime, endTime, entityType.name(), "API.startTime", requestHeaders);
+            forTenantId(tenantId), startTime, endTime, entityType.name(), "API.startTime");
     Map<EntityKey, Builder> entityKeyBuilderResponseMap =
         Map.of(
             EntityKey.of("entity-id-0"),
@@ -420,7 +420,7 @@ public class ExecutionVisitorTest {
         .thenReturn(Map.of("QS", List.of(selectionExpression)));
     when(executionContext.getEntitiesRequest()).thenReturn(entitiesRequest);
     when(executionContext.getTenantId()).thenReturn(tenantId);
-    when(executionContext.getRequestHeaders()).thenReturn(requestHeaders);
+    when(executionContext.getEntitiesRequestContext()).thenReturn(entitiesRequestContext);
     when(executionContext.getTimestampAttributeId()).thenReturn("API.startTime");
     when(queryServiceEntityFetcher.getEntities(eq(entitiesRequestContext), eq(entitiesRequest)))
         .thenReturn(entityFetcherResponse);
@@ -446,7 +446,6 @@ public class ExecutionVisitorTest {
     long startTime = 0;
     long endTime = 10;
     String tenantId = "TENANT_ID";
-    Map<String, String> requestHeaders = Map.of("x-tenant-id", tenantId);
     AttributeScope entityType = AttributeScope.API;
     Expression selectionExpression = buildExpression(API_NAME_ATTR);
     EntitiesRequest entitiesRequest =
@@ -462,7 +461,7 @@ public class ExecutionVisitorTest {
             .build();
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            tenantId, startTime, endTime, entityType.name(), "API.startTime", requestHeaders);
+            forTenantId(tenantId), startTime, endTime, entityType.name(), "API.startTime");
     Map<EntityKey, Builder> entityKeyBuilderResponseMap =
         Map.of(
             EntityKey.of("entity-id-0"),
@@ -478,7 +477,7 @@ public class ExecutionVisitorTest {
         .thenReturn(Map.of("QS", List.of(selectionExpression)));
     when(executionContext.getEntitiesRequest()).thenReturn(entitiesRequest);
     when(executionContext.getTenantId()).thenReturn(tenantId);
-    when(executionContext.getRequestHeaders()).thenReturn(requestHeaders);
+    when(executionContext.getEntitiesRequestContext()).thenReturn(entitiesRequestContext);
     when(executionContext.getTimestampAttributeId()).thenReturn("API.startTime");
     when(queryServiceEntityFetcher.getEntities(eq(entitiesRequestContext), eq(entitiesRequest)))
         .thenReturn(entityFetcherResponse);
@@ -504,7 +503,6 @@ public class ExecutionVisitorTest {
     long startTime = 0;
     long endTime = 10;
     String tenantId = "TENANT_ID";
-    Map<String, String> requestHeaders = Map.of("x-tenant-id", tenantId);
     AttributeScope entityType = AttributeScope.API;
     Expression selectionExpression = buildExpression(API_NAME_ATTR);
     EntitiesRequest entitiesRequest =
@@ -520,7 +518,7 @@ public class ExecutionVisitorTest {
             .build();
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            tenantId, startTime, endTime, entityType.name(), "API.startTime", requestHeaders);
+            forTenantId(tenantId), startTime, endTime, entityType.name(), "API.startTime");
     Map<EntityKey, Builder> entityKeyBuilderResponseMap =
         Map.of(
             EntityKey.of("entity-id-0"),
@@ -536,7 +534,7 @@ public class ExecutionVisitorTest {
         .thenReturn(Map.of("EDS", List.of(selectionExpression)));
     when(executionContext.getEntitiesRequest()).thenReturn(entitiesRequest);
     when(executionContext.getTenantId()).thenReturn(tenantId);
-    when(executionContext.getRequestHeaders()).thenReturn(requestHeaders);
+    when(executionContext.getEntitiesRequestContext()).thenReturn(entitiesRequestContext);
     when(executionContext.getTimestampAttributeId()).thenReturn("API.startTime");
     when(entityDataServiceEntityFetcher.getEntities(
             eq(entitiesRequestContext), eq(entitiesRequest)))
@@ -556,7 +554,6 @@ public class ExecutionVisitorTest {
     long startTime = 0;
     long endTime = 10;
     String tenantId = "TENANT_ID";
-    Map<String, String> requestHeaders = Map.of("x-tenant-id", tenantId);
     AttributeScope entityType = AttributeScope.API;
     Expression selectionExpression = buildExpression(API_NAME_ATTR);
     EntitiesRequest entitiesRequest =
@@ -569,7 +566,7 @@ public class ExecutionVisitorTest {
             .build();
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            tenantId, startTime, endTime, entityType.name(), "API.startTime", requestHeaders);
+            forTenantId(tenantId), startTime, endTime, entityType.name(), "API.startTime");
     Map<EntityKey, Builder> entityKeyBuilderResponseMap =
         Map.of(
             EntityKey.of("entity-id-0"),
@@ -585,7 +582,7 @@ public class ExecutionVisitorTest {
         .thenReturn(Map.of("QS", List.of(selectionExpression)));
     when(executionContext.getEntitiesRequest()).thenReturn(entitiesRequest);
     when(executionContext.getTenantId()).thenReturn(tenantId);
-    when(executionContext.getRequestHeaders()).thenReturn(requestHeaders);
+    when(executionContext.getEntitiesRequestContext()).thenReturn(entitiesRequestContext);
     when(executionContext.getTimestampAttributeId()).thenReturn("API.startTime");
     when(queryServiceEntityFetcher.getEntities(eq(entitiesRequestContext), eq(entitiesRequest)))
         .thenReturn(entityFetcherResponse);
@@ -611,7 +608,6 @@ public class ExecutionVisitorTest {
     long startTime = 0;
     long endTime = 10;
     String tenantId = "TENANT_ID";
-    Map<String, String> requestHeaders = Map.of("x-tenant-id", tenantId);
     AttributeScope entityType = AttributeScope.API;
     Expression selectionExpression = buildExpression(API_NAME_ATTR);
     Expression metricExpression =
@@ -635,7 +631,7 @@ public class ExecutionVisitorTest {
             .build();
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            tenantId, startTime, endTime, entityType.name(), "API.startTime", requestHeaders);
+            forTenantId(tenantId), startTime, endTime, entityType.name(), "API.startTime");
 
     // Order matters since we will do the pagination ourselves. So we use a LinkedHashMap
     Map<EntityKey, Builder> entityKeyBuilderResponseMap1 = new LinkedHashMap<>();
@@ -694,7 +690,7 @@ public class ExecutionVisitorTest {
         .thenReturn(Map.of("QS", List.of(timeAggregation)));
     when(executionContext.getEntitiesRequest()).thenReturn(entitiesRequest);
     when(executionContext.getTenantId()).thenReturn(tenantId);
-    when(executionContext.getRequestHeaders()).thenReturn(requestHeaders);
+    when(executionContext.getEntitiesRequestContext()).thenReturn(entitiesRequestContext);
     when(executionContext.getTimestampAttributeId()).thenReturn("API.startTime");
     EntitiesRequest entitiesRequestForAttributes =
         EntitiesRequest.newBuilder(entitiesRequest)
@@ -777,6 +773,8 @@ public class ExecutionVisitorTest {
     when(queryServiceEntityFetcher.getEntities(any(), any())).thenReturn(result4);
     when(executionVisitor.visit(any(NoOpNode.class)))
         .thenReturn(new EntityResponse(result4, result4.getEntityKeyBuilderMap().size()));
+    when(executionContext.getEntitiesRequestContext())
+        .thenReturn(mock(EntitiesRequestContext.class));
     executionVisitor.visit(selectionNode);
     verify(entityDataServiceEntityFetcher).getEntities(any(), any());
     verify(queryServiceEntityFetcher).getEntities(any(), any());
@@ -813,7 +811,7 @@ public class ExecutionVisitorTest {
             .build();
     EntitiesRequestContext entitiesRequestContext =
         new EntitiesRequestContext(
-            tenantId, startTime, endTime, entityType.name(), "API.startTime", requestHeaders);
+            forTenantId(tenantId), startTime, endTime, entityType.name(), "API.startTime");
 
     // Order matters since we will do the pagination ourselves. So we use a LinkedHashMap
     Map<EntityKey, Builder> entityKeyBuilderResponseMap1 = new LinkedHashMap<>();
@@ -862,7 +860,7 @@ public class ExecutionVisitorTest {
         .thenReturn(Map.of("QS", List.of(timeAggregation)));
     when(executionContext.getEntitiesRequest()).thenReturn(entitiesRequest);
     when(executionContext.getTenantId()).thenReturn(tenantId);
-    when(executionContext.getRequestHeaders()).thenReturn(requestHeaders);
+    when(executionContext.getEntitiesRequestContext()).thenReturn(entitiesRequestContext);
     when(executionContext.getTimestampAttributeId()).thenReturn("API.startTime");
     EntitiesRequest entitiesRequestForAttributes =
         EntitiesRequest.newBuilder(entitiesRequest)

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/explore/ExploreServiceTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/explore/ExploreServiceTest.java
@@ -1,12 +1,12 @@
 package org.hypertrace.gateway.service.explore;
 
 import com.google.protobuf.GeneratedMessageV3;
-import java.util.HashMap;
 import java.util.stream.Stream;
-import org.hypertrace.core.query.service.client.QueryServiceClient;
 import org.hypertrace.gateway.service.common.AbstractServiceTest;
 import org.hypertrace.gateway.service.common.AttributeMetadataProvider;
+import org.hypertrace.gateway.service.common.RequestContext;
 import org.hypertrace.gateway.service.common.config.ScopeFilterConfigs;
+import org.hypertrace.gateway.service.common.util.QueryServiceClient;
 import org.hypertrace.gateway.service.v1.explore.ExploreRequest;
 import org.hypertrace.gateway.service.v1.explore.ExploreResponse;
 
@@ -40,7 +40,10 @@ public class ExploreServiceTest extends AbstractServiceTest<ExploreRequest, Expl
       ScopeFilterConfigs scopeFilterConfigs) {
     ExploreService exploreService =
         new ExploreService(
-            queryServiceClient, 500, null, attributeMetadataProvider, scopeFilterConfigs, null);
-    return exploreService.explore(TENANT_ID, request, new HashMap<>());
+            queryServiceClient, null, attributeMetadataProvider, scopeFilterConfigs, null);
+    return exploreService.explore(
+        new RequestContext(
+            org.hypertrace.core.grpcutils.context.RequestContext.forTenantId(TENANT_ID)),
+        request);
   }
 }

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/explore/RequestHandlerTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/explore/RequestHandlerTest.java
@@ -3,8 +3,8 @@ package org.hypertrace.gateway.service.explore;
 import static org.mockito.Mockito.mock;
 
 import java.util.List;
-import org.hypertrace.core.query.service.client.QueryServiceClient;
 import org.hypertrace.gateway.service.common.AttributeMetadataProvider;
+import org.hypertrace.gateway.service.common.util.QueryServiceClient;
 import org.hypertrace.gateway.service.v1.common.ColumnIdentifier;
 import org.hypertrace.gateway.service.v1.common.Expression;
 import org.hypertrace.gateway.service.v1.common.FunctionExpression;
@@ -74,8 +74,7 @@ public class RequestHandlerTest {
             .build();
 
     RequestHandler requestHandler =
-        new RequestHandler(
-            mock(QueryServiceClient.class), 500, mock(AttributeMetadataProvider.class));
+        new RequestHandler(mock(QueryServiceClient.class), mock(AttributeMetadataProvider.class));
     List<OrderByExpression> orderByExpressions =
         requestHandler.getRequestOrderByExpressions(exploreRequest);
 
@@ -151,8 +150,7 @@ public class RequestHandlerTest {
             .build();
 
     RequestHandler requestHandler =
-        new RequestHandler(
-            mock(QueryServiceClient.class), 500, mock(AttributeMetadataProvider.class));
+        new RequestHandler(mock(QueryServiceClient.class), mock(AttributeMetadataProvider.class));
     List<OrderByExpression> orderByExpressions =
         requestHandler.getRequestOrderByExpressions(exploreRequest);
 
@@ -228,8 +226,7 @@ public class RequestHandlerTest {
             .build();
 
     RequestHandler requestHandler =
-        new RequestHandler(
-            mock(QueryServiceClient.class), 500, mock(AttributeMetadataProvider.class));
+        new RequestHandler(mock(QueryServiceClient.class), mock(AttributeMetadataProvider.class));
     List<OrderByExpression> orderByExpressions =
         requestHandler.getRequestOrderByExpressions(exploreRequest);
 
@@ -300,8 +297,7 @@ public class RequestHandlerTest {
             .build();
 
     RequestHandler requestHandler =
-        new RequestHandler(
-            mock(QueryServiceClient.class), 500, mock(AttributeMetadataProvider.class));
+        new RequestHandler(mock(QueryServiceClient.class), mock(AttributeMetadataProvider.class));
     List<OrderByExpression> orderByExpressions =
         requestHandler.getRequestOrderByExpressions(exploreRequest);
 

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/explore/TimeAggregationsRequestHandlerTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/explore/TimeAggregationsRequestHandlerTest.java
@@ -3,9 +3,9 @@ package org.hypertrace.gateway.service.explore;
 import static org.mockito.Mockito.mock;
 
 import java.util.List;
-import org.hypertrace.core.query.service.client.QueryServiceClient;
 import org.hypertrace.gateway.service.common.AttributeMetadataProvider;
 import org.hypertrace.gateway.service.common.util.QueryExpressionUtil;
+import org.hypertrace.gateway.service.common.util.QueryServiceClient;
 import org.hypertrace.gateway.service.v1.common.Expression;
 import org.hypertrace.gateway.service.v1.common.FunctionExpression;
 import org.hypertrace.gateway.service.v1.common.FunctionType;
@@ -64,7 +64,7 @@ public class TimeAggregationsRequestHandlerTest {
 
     TimeAggregationsRequestHandler requestHandler =
         new TimeAggregationsRequestHandler(
-            mock(QueryServiceClient.class), 500, mock(AttributeMetadataProvider.class));
+            mock(QueryServiceClient.class), mock(AttributeMetadataProvider.class));
     List<OrderByExpression> orderByExpressions =
         requestHandler.getRequestOrderByExpressions(exploreRequest);
 
@@ -119,7 +119,7 @@ public class TimeAggregationsRequestHandlerTest {
 
     TimeAggregationsRequestHandler requestHandler =
         new TimeAggregationsRequestHandler(
-            mock(QueryServiceClient.class), 500, mock(AttributeMetadataProvider.class));
+            mock(QueryServiceClient.class), mock(AttributeMetadataProvider.class));
     List<OrderByExpression> orderByExpressions =
         requestHandler.getRequestOrderByExpressions(exploreRequest);
 

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/explore/entity/EntityRequestHandlerTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/explore/entity/EntityRequestHandlerTest.java
@@ -1,12 +1,12 @@
 package org.hypertrace.gateway.service.explore.entity;
 
+import static org.hypertrace.core.grpcutils.context.RequestContext.forTenantId;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -14,7 +14,6 @@ import java.util.Optional;
 import java.util.Set;
 import org.hypertrace.core.attribute.service.v1.AttributeKind;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
-import org.hypertrace.core.query.service.client.QueryServiceClient;
 import org.hypertrace.entity.query.service.v1.ColumnMetadata;
 import org.hypertrace.entity.query.service.v1.ResultSetChunk;
 import org.hypertrace.entity.query.service.v1.ResultSetMetadata;
@@ -22,6 +21,7 @@ import org.hypertrace.entity.query.service.v1.Row;
 import org.hypertrace.gateway.service.common.AttributeMetadataProvider;
 import org.hypertrace.gateway.service.common.datafetcher.EntityFetcherResponse;
 import org.hypertrace.gateway.service.common.datafetcher.QueryServiceEntityFetcher;
+import org.hypertrace.gateway.service.common.util.QueryServiceClient;
 import org.hypertrace.gateway.service.entity.EntitiesRequestContext;
 import org.hypertrace.gateway.service.entity.EntityKey;
 import org.hypertrace.gateway.service.explore.ExploreRequestContext;
@@ -59,7 +59,6 @@ public class EntityRequestHandlerTest {
         new EntityRequestHandler(
             attributeMetadataProvider,
             mock(QueryServiceClient.class),
-            10,
             queryServiceEntityFetcher,
             entityServiceEntityFetcher);
   }
@@ -77,7 +76,7 @@ public class EntityRequestHandlerTest {
             .addGroupBy(createColumnExpression("API.type"))
             .build();
     ExploreRequestContext exploreRequestContext =
-        new ExploreRequestContext("customer1", exploreRequest, Collections.emptyMap());
+        new ExploreRequestContext(forTenantId("customer1"), exploreRequest);
     exploreRequestContext.mapAliasToFunctionExpression(
         "COUNT_API.external_[]", aggregation.getFunction());
 
@@ -142,7 +141,7 @@ public class EntityRequestHandlerTest {
             .addGroupBy(createColumnExpression("API.type"))
             .build();
     ExploreRequestContext exploreRequestContext =
-        new ExploreRequestContext("customer1", exploreRequest, Collections.emptyMap());
+        new ExploreRequestContext(forTenantId("customer1"), exploreRequest);
     exploreRequestContext.mapAliasToFunctionExpression(
         "COUNT_API.external_[]", aggregation.getFunction());
 

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/logevent/LogEventsServiceTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/logevent/LogEventsServiceTest.java
@@ -15,10 +15,10 @@ import java.util.Optional;
 import org.hypertrace.core.attribute.service.v1.AttributeKind;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
 import org.hypertrace.core.attribute.service.v1.AttributeType;
-import org.hypertrace.core.query.service.client.QueryServiceClient;
 import org.hypertrace.gateway.service.AbstractGatewayServiceTest;
 import org.hypertrace.gateway.service.common.AttributeMetadataProvider;
 import org.hypertrace.gateway.service.common.RequestContext;
+import org.hypertrace.gateway.service.common.util.QueryServiceClient;
 import org.hypertrace.gateway.service.v1.common.ColumnIdentifier;
 import org.hypertrace.gateway.service.v1.common.Expression;
 import org.hypertrace.gateway.service.v1.common.Filter;
@@ -132,7 +132,7 @@ public class LogEventsServiceTest extends AbstractGatewayServiceTest {
             .build();
 
     LogEventsService logEventsService =
-        new LogEventsService(queryServiceClient, 60_000, attributeMetadataProvider);
+        new LogEventsService(queryServiceClient, attributeMetadataProvider);
 
     String logAttributeString =
         new ObjectMapper()
@@ -141,7 +141,7 @@ public class LogEventsServiceTest extends AbstractGatewayServiceTest {
                     "event", "Acquired lock with 0 transaction waiting",
                     "network", "tcp",
                     "message", "Slow transaction"));
-    when(queryServiceClient.executeQuery(any(), any(), Mockito.anyInt()))
+    when(queryServiceClient.executeQuery(any(), any()))
         .thenReturn(
             List.of(
                     getResultSetChunk(
@@ -159,7 +159,9 @@ public class LogEventsServiceTest extends AbstractGatewayServiceTest {
 
     LogEventsResponse logEventsResponse =
         logEventsService.getLogEventsByFilter(
-            new RequestContext(TENANT_ID, Map.of()), logEventRequest);
+            new RequestContext(
+                org.hypertrace.core.grpcutils.context.RequestContext.forTenantId(TENANT_ID)),
+            logEventRequest);
 
     assertEquals(3, logEventsResponse.getLogEventsCount());
     logEventsResponse

--- a/gateway-service/src/main/resources/configs/common/application.conf
+++ b/gateway-service/src/main/resources/configs/common/application.conf
@@ -14,6 +14,7 @@ query.service.config = {
   host = ${?QUERY_SERVICE_HOST_CONFIG}
   port = 8090
   port = ${?QUERY_SERVICE_PORT_CONFIG}
+  request.timeout = 10000
 }
 attributes.service.config = {
   host = localhost


### PR DESCRIPTION
## Description
The goal of this PR is to update gateway service to use the common channel registry rather than building channels inline, allowing it to be a good citizen and share channels. As part of that, since it was using an old query service client that built its channel internally, I replaced it with a local client that also cleaned up a little bit about how timeout is propagated (building it into the client) and removing the explicit header propagation. This unfortunately led to a lot of minor code changes in a number of files, but no logic changes.

### Testing
Updated unit tests.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

