### PR TITLE
fix: restore removed config initialization

### DIFF
--- a/gateway-service-factory/src/main/java/org/hypertrace/gateway/service/GatewayServiceFactory.java
+++ b/gateway-service-factory/src/main/java/org/hypertrace/gateway/service/GatewayServiceFactory.java
@@ -4,12 +4,16 @@ import java.util.List;
 import org.hypertrace.core.serviceframework.grpc.GrpcPlatformService;
 import org.hypertrace.core.serviceframework.grpc.GrpcPlatformServiceFactory;
 import org.hypertrace.core.serviceframework.grpc.GrpcServiceContainerEnvironment;
+import org.hypertrace.gateway.service.entity.config.InteractionConfigs;
+import org.hypertrace.gateway.service.entity.config.TimestampConfigs;
 
 public class GatewayServiceFactory implements GrpcPlatformServiceFactory {
   private static final String SERVICE_NAME = "gateway-service";
 
   @Override
   public List<GrpcPlatformService> buildServices(GrpcServiceContainerEnvironment environment) {
+    InteractionConfigs.init(environment.getConfig(SERVICE_NAME));
+    TimestampConfigs.init(environment.getConfig(SERVICE_NAME));
     return List.of(
         new GrpcPlatformService(
             new GatewayServiceImpl(


### PR DESCRIPTION
## Description

This application config was previously initialized in the container code (?!), and was missed when we migrated containers ( https://github.com/hypertrace/gateway-service/commit/04e51b8657254f3d1966075cbe8c4d99c8cd9508#diff-8bf2eff6ecf87c5ce50dcc4bc191882f02fd44009aea35e7da4346a4e009ec25L36-L37 )

### Testing
E2E on local
