### PR TITLE
fix(entities): include inactive entities total

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/EntityDataServiceEntityFetcher.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/EntityDataServiceEntityFetcher.java
@@ -199,13 +199,15 @@ public class EntityDataServiceEntityFetcher implements IEntityFetcher {
                     entitiesRequest.getFilter()));
 
     // add time filter for supported scope
-    EntityServiceAndGatewayServiceConverter.addBetweenTimeFilter(
-        entitiesRequest.getStartTimeMillis(),
-        entitiesRequest.getEndTimeMillis(),
-        attributeMetadataProvider,
-        entitiesRequest,
-        builder,
-        requestContext);
+    if (!entitiesRequest.getIncludeNonLiveEntities()) {
+      EntityServiceAndGatewayServiceConverter.addBetweenTimeFilter(
+          entitiesRequest.getStartTimeMillis(),
+          entitiesRequest.getEndTimeMillis(),
+          attributeMetadataProvider,
+          entitiesRequest,
+          builder,
+          requestContext);
+    }
 
     EntityQueryRequest entityQueryRequest = builder.build();
 


### PR DESCRIPTION
## Description
If the `includeInactive` flag is set to `true`, then `getEntities` query is skipping adding timestamp filters on entities, while fetching the results https://github.com/hypertrace/gateway-service/blob/07539521826daa6d6df9a846e50650021e5817b9/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/common/datafetcher/EntityDataServiceEntityFetcher.java#L82

No such check exists while fetching the total. Timestamp filters are still getting added, even though the `includeInactive` flag is set to `true`. Hence, the inconsistency between entity results and total

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Added unit tests. Verified e2e locally

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
