### PR TITLE
fix: fix to handle group by with offset

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/RequestHandler.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/RequestHandler.java
@@ -175,7 +175,14 @@ public class RequestHandler implements RequestHandlerWithSorting {
       // we will add offset to limit itself and then ignore results till offset in response
       limit += request.getOffset();
       // don't exceed default group by limit
-      limit = Math.min(limit, DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT);
+      if (limit > DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT) {
+        LOG.error(
+            "Trying to query for rows more than the default limit {} : {}",
+            DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT,
+            request);
+        throw new UnsupportedOperationException(
+            "Trying to query for rows more than the default limit " + request);
+      }
       queryBuilder.setLimit(limit);
     } else {
       queryBuilder.setLimit(request.getLimit());

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/RequestHandler.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/RequestHandler.java
@@ -92,12 +92,15 @@ public class RequestHandler implements RequestHandlerWithSorting {
     builder.setFilter(
         constructQueryServiceFilter(request, requestContext, attributeMetadataProvider));
 
-    if (requestContext.hasGroupBy() && requestContext.getOffset() > 0) {
-      // providing both group by and offset doesn't provide right results in pinot
+    if (requestContext.hasGroupBy() && request.getIncludeRestGroup() && request.getOffset() > 0) {
+      // including rest group with offset is an invalid combination
       // throwing unsupported operation exception for this case
-      LOG.error("Query having group by along with offset is not supported : {}", request);
+      LOG.error(
+          "Query having group by with both offset and include rest is an invalid combination : {}",
+          request);
       throw new UnsupportedOperationException(
-          "Query with group by along with offset is not supported " + request);
+          "Query having group by with both offset and include rest is an invalid combination "
+              + request);
     }
 
     // 3. Add GroupBy
@@ -160,13 +163,20 @@ public class RequestHandler implements RequestHandlerWithSorting {
     }
 
     // handle group by scenario with group limit set
-    if (requestContext.hasGroupBy() && request.getGroupLimit() > 0) {
-      // in group by scenario, set limit to minimum of limit or group-limit
-      queryBuilder.setLimit(Math.min(request.getLimit(), request.getGroupLimit()));
+    if (requestContext.hasGroupBy()) {
+      int limit = request.getLimit();
+      if (request.getGroupLimit() > 0) {
+        // in group by scenario, set limit to minimum of limit or group-limit
+        limit = Math.min(request.getLimit(), request.getGroupLimit());
+      }
+      // pinot doesn't handle offset with group by correctly
+      // we will add offset to limit itself and then ignore results till offset in response
+      limit += request.getOffset();
+      queryBuilder.setLimit(limit);
     } else {
       queryBuilder.setLimit(request.getLimit());
+      queryBuilder.setOffset(request.getOffset());
     }
-    queryBuilder.setOffset(request.getOffset());
   }
 
   @Override
@@ -317,7 +327,14 @@ public class RequestHandler implements RequestHandlerWithSorting {
       List<OrderByExpression> orderByExpressions,
       int limit,
       int offset) {
-    // Nothing to do here
+    if (offset > 0) {
+      List<org.hypertrace.gateway.service.v1.common.Row.Builder> rowBuilders =
+          builder.getRowBuilderList();
+      List<org.hypertrace.gateway.service.v1.common.Row.Builder> rowBuildersPostSkip =
+          rowBuilders.stream().skip(offset).collect(Collectors.toUnmodifiableList());
+      builder.clearRow();
+      rowBuildersPostSkip.forEach(builder::addRow);
+    }
   }
 
   protected Logger getLogger() {

--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/RequestHandler.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/RequestHandler.java
@@ -1,5 +1,7 @@
 package org.hypertrace.gateway.service.explore;
 
+import static org.hypertrace.core.query.service.client.QueryServiceClient.DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT;
+
 import com.google.common.collect.Streams;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
@@ -172,6 +174,8 @@ public class RequestHandler implements RequestHandlerWithSorting {
       // pinot doesn't handle offset with group by correctly
       // we will add offset to limit itself and then ignore results till offset in response
       limit += request.getOffset();
+      // don't exceed default group by limit
+      limit = Math.min(limit, DEFAULT_QUERY_SERVICE_GROUP_BY_LIMIT);
       queryBuilder.setLimit(limit);
     } else {
       queryBuilder.setLimit(request.getLimit());

--- a/gateway-service-impl/src/test/resources/expected-test-responses/explore/group-by-with-offset.json
+++ b/gateway-service-impl/src/test/resources/expected-test-responses/explore/group-by-with-offset.json
@@ -1,0 +1,25 @@
+{
+  "row": [{
+    "columns": {
+      "SERVICE.name": {
+        "valueType": "STRING",
+        "string": "dummypartner"
+      },
+      "SUM_SERVICE.numCalls_[]": {
+        "valueType": "LONG",
+        "long": "136098"
+      }
+    }
+  }, {
+    "columns": {
+      "SERVICE.name": {
+        "valueType": "STRING",
+        "string": "nginx-traceshop"
+      },
+      "SUM_SERVICE.numCalls_[]": {
+        "valueType": "LONG",
+        "long": "136269"
+      }
+    }
+  }]
+}

--- a/gateway-service-impl/src/test/resources/query-service-requests-and-responses/explore/group-by-with-offset.json
+++ b/gateway-service-impl/src/test/resources/query-service-requests-and-responses/explore/group-by-with-offset.json
@@ -1,0 +1,141 @@
+[
+  {
+    "request": {
+      "filter": {
+        "childFilter": [
+          {
+            "lhs": {
+              "attributeExpression": {
+                "attributeId": "SERVICE.startTime"
+              }
+            },
+            "operator": "GE",
+            "rhs": {
+              "literal": {
+                "value": {
+                  "valueType": "LONG",
+                  "long": "1615593600000"
+                }
+              }
+            }
+          },
+          {
+            "lhs": {
+              "attributeExpression": {
+                "attributeId": "SERVICE.startTime"
+              }
+            },
+            "operator": "LT",
+            "rhs": {
+              "literal": {
+                "value": {
+                  "valueType": "LONG",
+                  "long": "1615844349000"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "selection": [
+        {
+          "function": {
+            "functionName": "SUM",
+            "arguments": [
+              {
+                "attributeExpression": {
+                  "attributeId": "SERVICE.numCalls"
+                }
+              }
+            ],
+            "alias": "SUM_SERVICE.numCalls_[]"
+          }
+        },
+        {
+          "attributeExpression": {
+            "attributeId": "SERVICE.name",
+            "alias": "SERVICE.name"
+          }
+        }
+      ],
+      "groupBy": [
+        {
+          "attributeExpression": {
+            "attributeId": "SERVICE.name",
+            "alias": "SERVICE.name"
+          }
+        }
+      ],
+      "orderBy": [{
+        "expression": {
+          "function": {
+            "functionName": "SUM",
+            "arguments": [{
+              "attributeExpression": {
+                "attributeId": "SERVICE.numCalls"
+              }
+            }],
+            "alias": "SUM_SERVICE.numCalls_[]"
+          }
+        },
+        "order": "DESC"
+      }],
+      "limit": 4
+    },
+    "response": {
+      "isLastChunk": true,
+      "resultSetMetadata": {
+        "columnMetadata": [
+          {
+            "columnName": "SERVICE.name"
+          },
+          {
+            "columnName": "SUM_SERVICE.numCalls_[]"
+          }
+        ]
+      },
+      "row": [
+        {
+          "column": [
+            {
+              "string": "checkoutservice"
+            },
+            {
+              "string": "154321.0"
+            }
+          ]
+        },
+        {
+          "column": [
+            {
+              "string": "dataservice"
+            },
+            {
+              "string": "145678.0"
+            }
+          ]
+        },
+        {
+          "column": [
+            {
+              "string": "dummypartner"
+            },
+            {
+              "string": "136098.0"
+            }
+          ]
+        },
+        {
+          "column": [
+            {
+              "string": "nginx-traceshop"
+            },
+            {
+              "string": "136269.0"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/gateway-service-impl/src/test/resources/test-requests/explore/group-by-with-offset.json
+++ b/gateway-service-impl/src/test/resources/test-requests/explore/group-by-with-offset.json
@@ -1,0 +1,42 @@
+{
+  "context": "SERVICE",
+  "startTimeMillis": "1615593600000",
+  "endTimeMillis": "1615844349000",
+  "filter": {
+  },
+  "selection": [{
+    "function": {
+      "function": "SUM",
+      "arguments": [{
+        "columnIdentifier": {
+          "columnName": "SERVICE.numCalls"
+        }
+      }],
+      "alias": "SUM_SERVICE.numCalls_[]"
+    }
+  }],
+  "groupBy": [{
+    "columnIdentifier": {
+      "columnName": "SERVICE.name",
+      "alias": "SERVICE.name"
+    }
+  }],
+  "orderBy": [{
+    "expression": {
+      "function": {
+        "function": "SUM",
+        "arguments": [
+          {
+            "columnIdentifier": {
+              "columnName": "SERVICE.numCalls"
+            }
+          }
+        ],
+        "alias": "SUM_SERVICE.numCalls_[]"
+      }
+    },
+    "order": "DESC"
+  }],
+  "offset": 2,
+  "limit": 2
+}


### PR DESCRIPTION
Group by query with offset doesn't retrieve right results from pinot. So here are the changes done -
1. In case offset is provided with group by query, we just add offset to limit itself when querying Pinot. We will just skip the results(from Pinot) till offset when returning final results to the caller.
2. The rest group doesn't make sense with pagination scenario(query with offset). Such query will result in UnsupportedOperationException
3. Ideally for pagination case, no group limit should be specified. In case it is specified, we will use limit as min(limit, group-limit) + offset to query pinot. 