### PR TITLE
fix: handles empty array in in clause filter

### DIFF
--- a/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/TimeAggregationsWithGroupByRequestHandler.java
+++ b/gateway-service-impl/src/main/java/org/hypertrace/gateway/service/explore/TimeAggregationsWithGroupByRequestHandler.java
@@ -228,7 +228,11 @@ public class TimeAggregationsWithGroupByRequestHandler implements IRequestHandle
         valueBuilder.addStringArray(value.getString());
         break;
       case STRING_ARRAY:
-        valueBuilder.addAllStringArray(value.getStringArrayList());
+        if (value.getStringArrayList().isEmpty()) {
+          valueBuilder.addAllStringArray(List.of("null"));
+        } else {
+          valueBuilder.addAllStringArray(value.getStringArrayList());
+        }
         break;
       case LONG:
         valueBuilder.addLongArray(value.getLong());

--- a/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/explore/TimeAggregationsWithGroupByRequestHandlerTest.java
+++ b/gateway-service-impl/src/test/java/org/hypertrace/gateway/service/explore/TimeAggregationsWithGroupByRequestHandlerTest.java
@@ -201,4 +201,302 @@ public class TimeAggregationsWithGroupByRequestHandlerTest {
         timeAggregationsWithGroupByRequestHandler.handleRequest(
             exploreRequestContext, exploreRequest));
   }
+
+  @Test
+  public void testTimeAggregationsWithGroupBy_Empty_multiValuedField() {
+    ExploreRequest exploreRequest =
+        ExploreRequest.newBuilder()
+            .setContext("API")
+            .setStartTimeMillis(0)
+            .setEndTimeMillis(100)
+            .addTimeAggregation(
+                TimeAggregation.newBuilder()
+                    .setPeriod(Period.newBuilder().setUnit("SECONDS").setValue(60))
+                    .setAggregation(
+                        Expression.newBuilder()
+                            .setFunction(
+                                FunctionExpression.newBuilder()
+                                    .setFunction(FunctionType.MAX)
+                                    .setAlias("MAX_Duration")
+                                    .addArguments(
+                                        QueryExpressionUtil.buildAttributeExpression(
+                                            "Api.Trace.metrics.duration_millis")))))
+            .addGroupBy(
+                Expression.newBuilder()
+                    .setColumnIdentifier(
+                        ColumnIdentifier.newBuilder().setColumnName("API.labels").build())
+                    .build())
+            .build();
+
+    ExploreRequestContext exploreRequestContext =
+        new ExploreRequestContext(mock(RequestContext.class), exploreRequest);
+    TimeAggregationsWithGroupByRequestHandler timeAggregationsWithGroupByRequestHandler =
+        new TimeAggregationsWithGroupByRequestHandler(
+            attributeMetadataProvider, normalRequestHandler, timeAggregationsRequestHandler);
+
+    ExploreRequest groupByRequest =
+        ExploreRequest.newBuilder()
+            .setContext("API")
+            .setStartTimeMillis(0)
+            .setEndTimeMillis(100)
+            .addSelection(
+                Expression.newBuilder()
+                    .setFunction(
+                        FunctionExpression.newBuilder()
+                            .setFunction(FunctionType.MAX)
+                            .setAlias("MAX_Duration")
+                            .addArguments(
+                                Expression.newBuilder()
+                                    .setAttributeExpression(
+                                        AttributeExpression.newBuilder()
+                                            .setAttributeId("Api.Trace.metrics.duration_millis"))
+                                    .build())
+                            .build())
+                    .build())
+            .addGroupBy(
+                Expression.newBuilder()
+                    .setColumnIdentifier(
+                        ColumnIdentifier.newBuilder().setColumnName("API.labels").build())
+                    .build())
+            .build();
+    ExploreResponse.Builder groupByExploreResponseBuilder =
+        ExploreResponse.newBuilder()
+            .addRow(
+                Row.newBuilder()
+                    .putColumns(
+                        "API.labels",
+                        Value.newBuilder()
+                            .setValueType(ValueType.STRING_ARRAY)
+                            .addAllStringArray(List.of())
+                            .build())
+                    .build());
+    when(normalRequestHandler.handleRequest(any(ExploreRequestContext.class), eq(groupByRequest)))
+        .thenReturn(groupByExploreResponseBuilder);
+    when(attributeMetadataProvider.getAttributesMetadata(
+            any(ExploreRequestContext.class), eq("API")))
+        .thenReturn(
+            Map.of(
+                "API.labels",
+                AttributeMetadata.newBuilder()
+                    .setValueKind(AttributeKind.TYPE_STRING_ARRAY)
+                    .build()));
+
+    ExploreRequest timeAggregationsRequest =
+        ExploreRequest.newBuilder()
+            .setContext("API")
+            .setStartTimeMillis(0)
+            .setEndTimeMillis(100)
+            .setFilter(
+                Filter.newBuilder()
+                    .setOperator(Operator.AND)
+                    .addChildFilter(
+                        Filter.newBuilder()
+                            .setLhs(
+                                Expression.newBuilder()
+                                    .setColumnIdentifier(
+                                        ColumnIdentifier.newBuilder()
+                                            .setColumnName("API.labels")
+                                            .build())
+                                    .build())
+                            .setOperator(Operator.IN)
+                            .setRhs(
+                                Expression.newBuilder()
+                                    .setLiteral(
+                                        LiteralConstant.newBuilder()
+                                            .setValue(
+                                                Value.newBuilder()
+                                                    .setValueType(ValueType.STRING_ARRAY)
+                                                    .addAllStringArray(List.of("null"))
+                                                    .build())
+                                            .build())
+                                    .build())
+                            .build())
+                    .build())
+            .addTimeAggregation(
+                TimeAggregation.newBuilder()
+                    .setPeriod(Period.newBuilder().setValue(60).setUnit("SECONDS").build())
+                    .setAggregation(
+                        Expression.newBuilder()
+                            .setFunction(
+                                FunctionExpression.newBuilder()
+                                    .setFunction(FunctionType.MAX)
+                                    .setAlias("MAX_Duration")
+                                    .addArguments(
+                                        Expression.newBuilder()
+                                            .setAttributeExpression(
+                                                AttributeExpression.newBuilder()
+                                                    .setAttributeId(
+                                                        "Api.Trace.metrics.duration_millis")
+                                                    .build())
+                                            .build())
+                                    .build())
+                            .build())
+                    .build())
+            .addGroupBy(
+                Expression.newBuilder()
+                    .setColumnIdentifier(
+                        ColumnIdentifier.newBuilder().setColumnName("API.labels").build())
+                    .build())
+            .build();
+
+    // dummy mock
+    ExploreResponse.Builder timeAggregationsResponseBuilder = ExploreResponse.newBuilder();
+    when(timeAggregationsRequestHandler.handleRequest(
+            any(ExploreRequestContext.class), eq(timeAggregationsRequest)))
+        .thenReturn(timeAggregationsResponseBuilder);
+
+    assertEquals(
+        timeAggregationsResponseBuilder,
+        timeAggregationsWithGroupByRequestHandler.handleRequest(
+            exploreRequestContext, exploreRequest));
+  }
+
+  @Test
+  public void testTimeAggregationsWithGroupBy_null_multiValuedField() {
+    ExploreRequest exploreRequest =
+        ExploreRequest.newBuilder()
+            .setContext("API")
+            .setStartTimeMillis(0)
+            .setEndTimeMillis(100)
+            .addTimeAggregation(
+                TimeAggregation.newBuilder()
+                    .setPeriod(Period.newBuilder().setUnit("SECONDS").setValue(60))
+                    .setAggregation(
+                        Expression.newBuilder()
+                            .setFunction(
+                                FunctionExpression.newBuilder()
+                                    .setFunction(FunctionType.MAX)
+                                    .setAlias("MAX_Duration")
+                                    .addArguments(
+                                        QueryExpressionUtil.buildAttributeExpression(
+                                            "Api.Trace.metrics.duration_millis")))))
+            .addGroupBy(
+                Expression.newBuilder()
+                    .setColumnIdentifier(
+                        ColumnIdentifier.newBuilder().setColumnName("API.labels").build())
+                    .build())
+            .build();
+
+    ExploreRequestContext exploreRequestContext =
+        new ExploreRequestContext(mock(RequestContext.class), exploreRequest);
+    TimeAggregationsWithGroupByRequestHandler timeAggregationsWithGroupByRequestHandler =
+        new TimeAggregationsWithGroupByRequestHandler(
+            attributeMetadataProvider, normalRequestHandler, timeAggregationsRequestHandler);
+
+    ExploreRequest groupByRequest =
+        ExploreRequest.newBuilder()
+            .setContext("API")
+            .setStartTimeMillis(0)
+            .setEndTimeMillis(100)
+            .addSelection(
+                Expression.newBuilder()
+                    .setFunction(
+                        FunctionExpression.newBuilder()
+                            .setFunction(FunctionType.MAX)
+                            .setAlias("MAX_Duration")
+                            .addArguments(
+                                Expression.newBuilder()
+                                    .setAttributeExpression(
+                                        AttributeExpression.newBuilder()
+                                            .setAttributeId("Api.Trace.metrics.duration_millis"))
+                                    .build())
+                            .build())
+                    .build())
+            .addGroupBy(
+                Expression.newBuilder()
+                    .setColumnIdentifier(
+                        ColumnIdentifier.newBuilder().setColumnName("API.labels").build())
+                    .build())
+            .build();
+    ExploreResponse.Builder groupByExploreResponseBuilder =
+        ExploreResponse.newBuilder()
+            .addRow(
+                Row.newBuilder()
+                    .putColumns(
+                        "API.labels",
+                        Value.newBuilder()
+                            .setValueType(ValueType.STRING_ARRAY)
+                            .addAllStringArray(List.of("null"))
+                            .build())
+                    .build());
+    when(normalRequestHandler.handleRequest(any(ExploreRequestContext.class), eq(groupByRequest)))
+        .thenReturn(groupByExploreResponseBuilder);
+    when(attributeMetadataProvider.getAttributesMetadata(
+            any(ExploreRequestContext.class), eq("API")))
+        .thenReturn(
+            Map.of(
+                "API.labels",
+                AttributeMetadata.newBuilder()
+                    .setValueKind(AttributeKind.TYPE_STRING_ARRAY)
+                    .build()));
+
+    ExploreRequest timeAggregationsRequest =
+        ExploreRequest.newBuilder()
+            .setContext("API")
+            .setStartTimeMillis(0)
+            .setEndTimeMillis(100)
+            .setFilter(
+                Filter.newBuilder()
+                    .setOperator(Operator.AND)
+                    .addChildFilter(
+                        Filter.newBuilder()
+                            .setLhs(
+                                Expression.newBuilder()
+                                    .setColumnIdentifier(
+                                        ColumnIdentifier.newBuilder()
+                                            .setColumnName("API.labels")
+                                            .build())
+                                    .build())
+                            .setOperator(Operator.IN)
+                            .setRhs(
+                                Expression.newBuilder()
+                                    .setLiteral(
+                                        LiteralConstant.newBuilder()
+                                            .setValue(
+                                                Value.newBuilder()
+                                                    .setValueType(ValueType.STRING_ARRAY)
+                                                    .addStringArray("null")
+                                                    .build())
+                                            .build())
+                                    .build())
+                            .build())
+                    .build())
+            .addTimeAggregation(
+                TimeAggregation.newBuilder()
+                    .setPeriod(Period.newBuilder().setValue(60).setUnit("SECONDS").build())
+                    .setAggregation(
+                        Expression.newBuilder()
+                            .setFunction(
+                                FunctionExpression.newBuilder()
+                                    .setFunction(FunctionType.MAX)
+                                    .setAlias("MAX_Duration")
+                                    .addArguments(
+                                        Expression.newBuilder()
+                                            .setAttributeExpression(
+                                                AttributeExpression.newBuilder()
+                                                    .setAttributeId(
+                                                        "Api.Trace.metrics.duration_millis")
+                                                    .build())
+                                            .build())
+                                    .build())
+                            .build())
+                    .build())
+            .addGroupBy(
+                Expression.newBuilder()
+                    .setColumnIdentifier(
+                        ColumnIdentifier.newBuilder().setColumnName("API.labels").build())
+                    .build())
+            .build();
+
+    // dummy mock
+    ExploreResponse.Builder timeAggregationsResponseBuilder = ExploreResponse.newBuilder();
+    when(timeAggregationsRequestHandler.handleRequest(
+            any(ExploreRequestContext.class), eq(timeAggregationsRequest)))
+        .thenReturn(timeAggregationsResponseBuilder);
+
+    assertEquals(
+        timeAggregationsResponseBuilder,
+        timeAggregationsWithGroupByRequestHandler.handleRequest(
+            exploreRequestContext, exploreRequest));
+  }
 }


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
